### PR TITLE
fix: Move theme selector from header to Settings sidebar

### DIFF
--- a/dashboard/css/themes.css
+++ b/dashboard/css/themes.css
@@ -436,3 +436,96 @@
 .preview-ocean span:nth-child(1) { background: #021014; }
 .preview-ocean span:nth-child(2) { background: #00e5cc; }
 .preview-ocean span:nth-child(3) { background: #004d44; }
+
+/* ============================================
+   SIDEBAR THEME GRID
+   ============================================ */
+.theme-setting {
+    flex-direction: column;
+    align-items: flex-start !important;
+}
+
+.theme-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.5rem;
+    width: 100%;
+    margin-top: 0.5rem;
+}
+
+.theme-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.5rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: all var(--transition-fast);
+}
+
+.theme-card:hover {
+    border-color: var(--accent-primary);
+    background: var(--bg-card-hover);
+}
+
+.theme-card.active {
+    border-color: var(--accent-primary);
+    box-shadow: 0 0 10px var(--accent-glow);
+}
+
+.theme-preview {
+    display: flex;
+    gap: 2px;
+    padding: 2px;
+    background: rgba(0,0,0,0.3);
+    border-radius: 3px;
+}
+
+.theme-preview span {
+    width: 14px;
+    height: 14px;
+    border-radius: 2px;
+}
+
+.theme-label {
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+    font-family: var(--theme-font-body, 'Rajdhani', sans-serif);
+}
+
+.theme-card.active .theme-label {
+    color: var(--accent-primary);
+}
+
+/* Mode Toggle */
+.mode-toggle {
+    display: flex;
+    gap: 0.5rem;
+    width: 100%;
+}
+
+.mode-btn {
+    flex: 1;
+    padding: 0.5rem;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-color);
+    background: var(--bg-card);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 0.8rem;
+    transition: all var(--transition-fast);
+}
+
+.mode-btn:hover {
+    border-color: var(--accent-primary);
+    color: var(--text-primary);
+}
+
+.mode-btn.active {
+    background: var(--accent-glow);
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
+}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -32,52 +32,6 @@
             <span class="version">v0.9.2</span>
         </div>
         <div class="header-right">
-            <!-- Theme Selector -->
-            <div class="theme-selector" id="theme-selector">
-                <button class="theme-selector-btn" id="theme-selector-btn" aria-label="Select theme">
-                    <span class="theme-icon"></span>
-                    <span class="theme-current-name">Matrix</span>
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <polyline points="6 9 12 15 18 9"></polyline>
-                    </svg>
-                </button>
-                <div class="theme-dropdown" id="theme-dropdown">
-                    <button class="theme-option active" data-color-theme="matrix">
-                        <div class="theme-color-preview preview-matrix"><span></span><span></span><span></span></div>
-                        <span class="theme-name">Matrix</span>
-                    </button>
-                    <button class="theme-option" data-color-theme="jarvis">
-                        <div class="theme-color-preview preview-jarvis"><span></span><span></span><span></span></div>
-                        <span class="theme-name">JARVIS</span>
-                    </button>
-                    <button class="theme-option" data-color-theme="cyberpunk">
-                        <div class="theme-color-preview preview-cyberpunk"><span></span><span></span><span></span></div>
-                        <span class="theme-name">Cyberpunk</span>
-                    </button>
-                    <button class="theme-option" data-color-theme="amber">
-                        <div class="theme-color-preview preview-amber"><span></span><span></span><span></span></div>
-                        <span class="theme-name">Amber Terminal</span>
-                    </button>
-                    <button class="theme-option" data-color-theme="midnight">
-                        <div class="theme-color-preview preview-midnight"><span></span><span></span><span></span></div>
-                        <span class="theme-name">Midnight</span>
-                    </button>
-                    <button class="theme-option" data-color-theme="ironman">
-                        <div class="theme-color-preview preview-ironman"><span></span><span></span><span></span></div>
-                        <span class="theme-name">Iron Man</span>
-                    </button>
-                    <button class="theme-option" data-color-theme="ocean">
-                        <div class="theme-color-preview preview-ocean"><span></span><span></span><span></span></div>
-                        <span class="theme-name">Ocean</span>
-                    </button>
-                    <hr style="border-color: var(--border-color); margin: 0.5rem 0;">
-                    <div class="theme-mode-toggle" style="display: flex; gap: 0.5rem; padding: 0.5rem;">
-                        <button class="theme-toggle-btn active" data-theme="dark" title="Dark mode" style="flex:1; padding: 0.5rem; border-radius: var(--radius-md); border: 1px solid var(--border-color); background: var(--bg-card); color: var(--text-primary); cursor: pointer;">🌙 Dark</button>
-                        <button class="theme-toggle-btn" data-theme="light" title="Light mode" style="flex:1; padding: 0.5rem; border-radius: var(--radius-md); border: 1px solid var(--border-color); background: var(--bg-card); color: var(--text-primary); cursor: pointer;">☀️ Light</button>
-                    </div>
-                </div>
-            </div>
-
             <div class="metrics">
                 <div class="metric">
                     <span class="metric-value" id="total-tasks">0</span>
@@ -332,6 +286,50 @@
                         <label for="dashboard-name">Dashboard Name</label>
                         <input type="text" id="dashboard-name" value="JARVIS Mission Control" placeholder="Enter dashboard name...">
                         <button class="btn-small" onclick="saveDashboardName()">Save</button>
+                    </div>
+
+                    <!-- Theme Selection -->
+                    <div class="setting-item theme-setting">
+                        <label>Theme</label>
+                        <div class="theme-grid" id="theme-grid">
+                            <button class="theme-card active" data-color-theme="matrix" title="Matrix">
+                                <div class="theme-preview preview-matrix"><span></span><span></span><span></span></div>
+                                <span class="theme-label">Matrix</span>
+                            </button>
+                            <button class="theme-card" data-color-theme="jarvis" title="JARVIS">
+                                <div class="theme-preview preview-jarvis"><span></span><span></span><span></span></div>
+                                <span class="theme-label">JARVIS</span>
+                            </button>
+                            <button class="theme-card" data-color-theme="cyberpunk" title="Cyberpunk">
+                                <div class="theme-preview preview-cyberpunk"><span></span><span></span><span></span></div>
+                                <span class="theme-label">Cyberpunk</span>
+                            </button>
+                            <button class="theme-card" data-color-theme="amber" title="Amber Terminal">
+                                <div class="theme-preview preview-amber"><span></span><span></span><span></span></div>
+                                <span class="theme-label">Amber</span>
+                            </button>
+                            <button class="theme-card" data-color-theme="midnight" title="Midnight">
+                                <div class="theme-preview preview-midnight"><span></span><span></span><span></span></div>
+                                <span class="theme-label">Midnight</span>
+                            </button>
+                            <button class="theme-card" data-color-theme="ironman" title="Iron Man">
+                                <div class="theme-preview preview-ironman"><span></span><span></span><span></span></div>
+                                <span class="theme-label">Iron Man</span>
+                            </button>
+                            <button class="theme-card" data-color-theme="ocean" title="Ocean">
+                                <div class="theme-preview preview-ocean"><span></span><span></span><span></span></div>
+                                <span class="theme-label">Ocean</span>
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Dark/Light Mode -->
+                    <div class="setting-item">
+                        <label>Mode</label>
+                        <div class="mode-toggle">
+                            <button class="mode-btn active" data-theme="dark" title="Dark mode">🌙 Dark</button>
+                            <button class="mode-btn" data-theme="light" title="Light mode">☀️ Light</button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -192,40 +192,21 @@ function initTheme() {
     applyTheme(currentTheme);
     applyColorTheme(currentColorTheme);
 
-    // Setup dark/light mode toggle listeners
-    document.querySelectorAll('.theme-toggle-btn').forEach(btn => {
+    // Setup dark/light mode toggle listeners (both old and new selectors)
+    document.querySelectorAll('.theme-toggle-btn, .mode-btn').forEach(btn => {
         btn.addEventListener('click', () => {
             const theme = btn.dataset.theme;
             setTheme(theme);
         });
     });
 
-    // Setup color theme selector
-    const themeSelectorBtn = document.getElementById('theme-selector-btn');
-    const themeDropdown = document.getElementById('theme-dropdown');
-
-    if (themeSelectorBtn && themeDropdown) {
-        themeSelectorBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            themeDropdown.classList.toggle('open');
+    // Setup color theme grid in sidebar
+    document.querySelectorAll('.theme-card').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const colorTheme = btn.dataset.colorTheme;
+            setColorTheme(colorTheme);
         });
-
-        // Close dropdown when clicking outside
-        document.addEventListener('click', (e) => {
-            if (!e.target.closest('.theme-selector')) {
-                themeDropdown.classList.remove('open');
-            }
-        });
-
-        // Color theme options
-        document.querySelectorAll('.theme-option').forEach(btn => {
-            btn.addEventListener('click', () => {
-                const colorTheme = btn.dataset.colorTheme;
-                setColorTheme(colorTheme);
-                themeDropdown.classList.remove('open');
-            });
-        });
-    }
+    });
 
     // Listen for system theme changes
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
@@ -250,8 +231,8 @@ function setTheme(theme) {
 function applyTheme(theme) {
     document.documentElement.setAttribute('data-theme', theme);
 
-    // Update toggle buttons
-    document.querySelectorAll('.theme-toggle-btn').forEach(btn => {
+    // Update all toggle buttons (both old and new selectors)
+    document.querySelectorAll('.theme-toggle-btn, .mode-btn').forEach(btn => {
         btn.classList.toggle('active', btn.dataset.theme === theme);
     });
 }
@@ -271,25 +252,10 @@ function setColorTheme(colorTheme) {
 function applyColorTheme(colorTheme) {
     document.documentElement.setAttribute('data-color-theme', colorTheme);
 
-    // Update theme option buttons
-    document.querySelectorAll('.theme-option').forEach(btn => {
+    // Update theme cards in sidebar
+    document.querySelectorAll('.theme-card').forEach(btn => {
         btn.classList.toggle('active', btn.dataset.colorTheme === colorTheme);
     });
-
-    // Update theme selector button text
-    const themeNames = {
-        'matrix': 'Matrix',
-        'jarvis': 'JARVIS',
-        'cyberpunk': 'Cyberpunk',
-        'amber': 'Amber Terminal',
-        'midnight': 'Midnight',
-        'ironman': 'Iron Man',
-        'ocean': 'Ocean'
-    };
-    const currentNameEl = document.querySelector('.theme-current-name');
-    if (currentNameEl) {
-        currentNameEl.textContent = themeNames[colorTheme] || colorTheme;
-    }
 }
 
 /**


### PR DESCRIPTION
## Issue

Theme selector was in header dropdown. Architect requested it in Settings sidebar.

## Changes

- ❌ Removed theme dropdown from header
- ✅ Added theme grid in **Settings → Theme**
- ✅ Dark/Light mode toggle in Settings

### New Location

```
Right Sidebar → Settings → Theme
```

### Theme Grid

- Visual cards with color previews
- Click to select, saves to localStorage
- Clean header without dropdown clutter

**Note:** This commit was missed in PR #27 merge.

[agent:morpheus]