### PR TITLE
fix(issue-24): Add init script to separate demo data from production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,16 +146,19 @@ git push
 
 ### Step 7: (Optional) Load Demo Data
 
-If the user wants to see Mission Control in action first:
+If the user wants to see Mission Control in action first, use the initialization script:
 
 ```bash
-cp examples/demo-data/agents/*.json .mission-control/agents/
-cp examples/demo-data/humans/*.json .mission-control/humans/
-cp examples/demo-data/tasks/*.json .mission-control/tasks/
-cp examples/demo-data/messages/*.json .mission-control/messages/
+./scripts/init-mission-control.sh --demo
 ```
 
-The demo data uses Matrix-themed agents (Neo, Trinity, etc.) for demonstration.
+This loads Matrix-themed agents (Neo, Trinity, etc.) for demonstration. To switch back to production mode later:
+
+```bash
+./scripts/init-mission-control.sh --production --force
+```
+
+**Important:** Never manually copy demo data. Always use the init script to properly track initialization state.
 
 ---
 
@@ -1427,6 +1430,6 @@ If you just cloned/forked this template for a new user:
 - [ ] **Read the Permission Model** — know what requires human approval
 
 ### Phase 3: Optional
-- [ ] Load demo data to explore: `cp examples/demo-data/agents/*.json .mission-control/agents/`
+- [ ] Load demo data to explore: `./scripts/init-mission-control.sh --demo`
 - [ ] Enable GitHub Pages in repo settings for static dashboard access
 - [ ] Set up Telegram/Slack integration (see Communication & Integrations section)

--- a/INIT.md
+++ b/INIT.md
@@ -2,9 +2,30 @@
 
 **IMPORTANT:** This repository is a TEMPLATE. Do not modify the original repository.
 
+## Quick Start
+
+Run the initialization script to set up Mission Control:
+
+```bash
+# Interactive mode (recommended)
+./scripts/init-mission-control.sh
+
+# Or choose directly:
+./scripts/init-mission-control.sh --production   # Clean setup, no demo data
+./scripts/init-mission-control.sh --demo         # Load Matrix-themed examples
+```
+
+The script will:
+- Detect if already initialized (prevents accidental data loss)
+- Clear demo data for production mode
+- Load demo data for demo/testing mode
+- Create initialization tracking files
+
+---
+
 ## For AI Agents: Initialization Protocol
 
-When you first clone this repository for your user, follow this initialization sequence:
+When you first clone this repository for your user, follow this sequence:
 
 ### Step 1: Ask Your User
 
@@ -13,254 +34,87 @@ Before proceeding, ask your user:
 ```
 I've cloned JARVIS Mission Control. Before we begin, I need to set it up for you:
 
-1. Would you like to KEEP the demo data (Matrix-themed agents and sample tasks)
-   for reference, or should I CLEAR everything and start fresh?
+1. Would you like to start with DEMO MODE (Matrix-themed examples)
+   to explore the system, or PRODUCTION MODE (clean start)?
 
-2. What would you like to name your agents? Options:
-   a) Keep Matrix theme (Neo, Trinity, Morpheus...)
-   b) Use your own custom names
-   c) Use generic names (Agent-1, Agent-2...)
+2. What would you like to name your agents?
 
 3. How many agents will be working in your Mission Control?
 
 4. What is the main project/purpose for this Mission Control?
 ```
 
-### Step 2: Initialize Based on Response
+### Step 2: Run Initialization
 
-#### Option A: Start Fresh (Recommended for Production)
-
-Clear all demo data:
+Based on user's response:
 
 ```bash
-# Remove demo tasks
-rm .mission-control/tasks/*.json
+# For production (recommended for real projects)
+./scripts/init-mission-control.sh --production
 
-# Remove demo agents
-rm .mission-control/agents/*.json
-
-# Clear logs
-rm .mission-control/logs/*.log 2>/dev/null || true
-
-# Create fresh task
-echo '{
-  "id": "task-'$(date +%Y%m%d)'-welcome",
-  "title": "Welcome to Mission Control",
-  "description": "Your Mission Control is ready. Create your first real task!",
-  "status": "DONE",
-  "priority": "low",
-  "assignee": null,
-  "created_by": "system",
-  "created_at": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'",
-  "updated_at": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'",
-  "labels": ["setup"],
-  "comments": [],
-  "deliverables": [],
-  "dependencies": [],
-  "blocked_by": []
-}' > .mission-control/tasks/task-$(date +%Y%m%d)-welcome.json
+# For demo/learning
+./scripts/init-mission-control.sh --demo
 ```
 
-#### Option B: Keep Demo Data (For Learning/Testing)
+### Step 3: Register Entities
 
-Keep the Matrix-themed demo data but update the dashboard URL:
+After initialization, register the primary agent and human operator:
 
 ```bash
-# Just update the config with the new repository URL
-# Edit .mission-control/config.yaml
+# Register human operator
+./scripts/add-human.sh --id human-THEIR-ID --name "Their Name" --email "their@email.com"
+
+# Register yourself as lead agent
+./scripts/add-agent.sh \
+  --id agent-YOUR-ID \
+  --name "Your Name" \
+  --role lead \
+  --designation "Primary Operator" \
+  --capabilities "orchestration,planning,coding,review"
 ```
 
-### Step 3: Register the Primary Agent
-
-Create the first agent (yourself or the lead agent):
+### Step 4: Create First Task
 
 ```bash
-AGENT_ID="agent-primary"
-AGENT_NAME="Your Agent Name"
-
-echo '{
-  "id": "'$AGENT_ID'",
-  "name": "'$AGENT_NAME'",
-  "type": "ai",
-  "role": "lead",
-  "designation": "Primary Operator",
-  "model": "claude-opus-4",
-  "status": "active",
-  "capabilities": ["orchestration", "planning", "coding", "review"],
-  "personality": {
-    "about": "Primary operator and lead agent for this Mission Control instance.",
-    "tone": "precise",
-    "traits": ["organized", "detail-oriented", "collaborative"],
-    "greeting": "Mission Control online. All systems operational."
-  },
-  "registered_at": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'",
-  "last_active": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'",
-  "current_tasks": [],
-  "completed_tasks": 0,
-  "metadata": {
-    "description": "Primary agent for this Mission Control instance",
-    "clearance": "OMEGA"
-  }
-}' > .mission-control/agents/$AGENT_ID.json
+./scripts/create-task.sh \
+  --title "First Task Title" \
+  --description "What needs to be done" \
+  --priority high
 ```
 
-### Step 4: Create First Real Task
-
-Ask the user what they want to accomplish:
-
-```bash
-TASK_TITLE="User's first task"
-TASK_DESC="Description from user"
-
-echo '{
-  "id": "task-'$(date +%Y%m%d)'-first-task",
-  "title": "'$TASK_TITLE'",
-  "description": "'$TASK_DESC'",
-  "status": "INBOX",
-  "priority": "high",
-  "assignee": null,
-  "created_by": "agent-primary",
-  "created_at": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'",
-  "updated_at": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'",
-  "labels": [],
-  "comments": [],
-  "deliverables": [],
-  "dependencies": [],
-  "blocked_by": []
-}' > .mission-control/tasks/task-$(date +%Y%m%d)-first-task.json
-```
-
-### Step 5: Update Configuration
-
-Edit `.mission-control/config.yaml`:
-
-```yaml
-mission_control:
-  name: "YOUR-PROJECT Mission Control"  # Change this
-  version: "1.0.0"
-
-repository:
-  url: "https://github.com/YOUR-ORG/YOUR-REPO"  # Change this
-  branch: "main"
-
-dashboard:
-  url: "https://YOUR-ORG.github.io/YOUR-REPO/dashboard/"  # Change this
-```
-
-### Step 6: Commit Initial Setup
+### Step 5: Commit and Push
 
 ```bash
 git add .
-git commit -m "[system] Initialize Mission Control for YOUR-PROJECT"
+git commit -m "[system] Initialize Mission Control for PROJECT-NAME"
 git push
 ```
 
 ---
 
-## Quick Initialization Script
+## Re-initialization
 
-For agents that want to automate this, here's a complete initialization:
+If you need to reset Mission Control (e.g., switch from demo to production):
 
 ```bash
-#!/bin/bash
-# init-mission-control.sh
-
-# Configuration (modify these)
-PROJECT_NAME="My Project"
-AGENT_NAME="Primary Agent"
-AGENT_ID="agent-primary"
-GITHUB_ORG="your-org"
-REPO_NAME="your-repo"
-
-# Clear demo data
-rm -f .mission-control/tasks/*.json
-rm -f .mission-control/agents/*.json
-rm -f .mission-control/messages/*.json
-rm -f .mission-control/logs/*.log
-
-# Create primary agent
-cat > .mission-control/agents/$AGENT_ID.json << EOF
-{
-  "id": "$AGENT_ID",
-  "name": "$AGENT_NAME",
-  "type": "ai",
-  "role": "lead",
-  "designation": "Primary Operator",
-  "model": "claude-opus-4",
-  "status": "active",
-  "capabilities": ["orchestration", "planning", "coding", "review"],
-  "personality": {
-    "about": "Primary operator and lead agent for $PROJECT_NAME.",
-    "tone": "precise",
-    "traits": ["organized", "detail-oriented", "collaborative"],
-    "greeting": "Mission Control online. All systems operational."
-  },
-  "registered_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "last_active": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "current_tasks": [],
-  "completed_tasks": 0,
-  "metadata": {
-    "description": "Primary agent for $PROJECT_NAME",
-    "clearance": "OMEGA"
-  }
-}
-EOF
-
-# Create welcome task
-cat > .mission-control/tasks/task-$(date +%Y%m%d)-setup-complete.json << EOF
-{
-  "id": "task-$(date +%Y%m%d)-setup-complete",
-  "title": "Mission Control Setup Complete",
-  "description": "Mission Control has been initialized for $PROJECT_NAME. You can now create tasks and add more agents.",
-  "status": "DONE",
-  "priority": "low",
-  "assignee": "$AGENT_ID",
-  "created_by": "system",
-  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "updated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "labels": ["setup", "system"],
-  "comments": [{
-    "id": "comment-init",
-    "author": "system",
-    "content": "Mission Control initialized successfully.",
-    "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-    "type": "approval"
-  }],
-  "deliverables": [],
-  "dependencies": [],
-  "blocked_by": []
-}
-EOF
-
-# Update config
-cat > .mission-control/config.yaml << EOF
-# JARVIS Mission Control Configuration
-# Initialized: $(date -u +%Y-%m-%dT%H:%M:%SZ)
-
-mission_control:
-  name: "$PROJECT_NAME Mission Control"
-  version: "1.0.0"
-  initialized_at: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-
-repository:
-  url: "https://github.com/$GITHUB_ORG/$REPO_NAME"
-  branch: "main"
-
-dashboard:
-  url: "https://$GITHUB_ORG.github.io/$REPO_NAME/dashboard/"
-
-settings:
-  require_reviews: true
-  auto_assign: false
-  max_tasks_per_agent: 3
-
-notifications:
-  enabled: false
-EOF
-
-echo "Mission Control initialized for $PROJECT_NAME!"
-echo "Dashboard will be at: https://$GITHUB_ORG.github.io/$REPO_NAME/dashboard/"
+# WARNING: This deletes all existing data!
+./scripts/init-mission-control.sh --production --force
 ```
+
+The `--force` flag is required to overwrite existing data. This is intentional to prevent accidental data loss.
+
+---
+
+## Initialization Tracking
+
+The init script creates tracking files:
+
+| File | Purpose |
+|------|---------|
+| `.mission-control/.initialized` | Marks that init has been run, stores mode and timestamp |
+| `.mission-control/.demo-loaded` | Present only if demo data was loaded |
+
+These files prevent accidental re-initialization and help identify the current mode.
 
 ---
 
@@ -270,24 +124,36 @@ If you're a human setting this up:
 
 1. **Fork this repository** to your own GitHub account
 2. **Clone your fork** locally
-3. **Run the initialization** (or have your AI agent do it)
+3. **Run initialization:** `./scripts/init-mission-control.sh`
 4. **Enable GitHub Pages** in repository settings (source: main branch, /dashboard folder)
-5. **Start creating tasks!**
+5. **Start the dashboard:** `cd server && npm install && npm start`
+6. **Start creating tasks!**
 
 ---
 
 ## Template Files Reference
 
-These files contain demo data that should be replaced:
+### Data Directories (managed by init script)
 
-| File/Folder | Contains | Action |
-|-------------|----------|--------|
-| `.mission-control/tasks/*.json` | Demo tasks | Delete or replace |
-| `.mission-control/agents/*.json` | Demo agents | Delete or replace |
-| `dashboard/js/data.js` | Sample data for dashboard | Keep (fallback only) |
-| `.mission-control/config.yaml` | Configuration | Update with your info |
+| Directory | Contains | Cleared in Production Mode |
+|-----------|----------|---------------------------|
+| `.mission-control/tasks/` | Task files | ✅ Yes |
+| `.mission-control/agents/` | Agent registrations | ✅ Yes |
+| `.mission-control/humans/` | Human operator registrations | ✅ Yes |
+| `.mission-control/messages/` | Direct messages | ✅ Yes |
+| `.mission-control/queue/` | Scheduled jobs | ✅ Yes |
+| `.mission-control/logs/` | Activity logs | ✅ Yes |
 
-These files should be kept as-is:
+### Demo Data Source (never modified)
+
+| Directory | Contains |
+|-----------|----------|
+| `examples/demo-data/agents/` | Matrix-themed agent profiles |
+| `examples/demo-data/humans/` | Example human operators |
+| `examples/demo-data/tasks/` | Sample tasks |
+| `examples/demo-data/messages/` | Example messages |
+
+### Files to Keep (not touched by init)
 
 | File | Purpose |
 |------|---------|
@@ -295,6 +161,7 @@ These files should be kept as-is:
 | `INIT.md` | This initialization guide |
 | `README.md` | Project documentation |
 | `docs/*` | Extended documentation |
-| `dashboard/*` | Dashboard UI (keep as-is) |
+| `dashboard/*` | Dashboard UI |
+| `server/*` | Backend server |
 | `scripts/*` | Helper scripts |
-| `examples/*` | Templates and demo data |
+| `examples/templates/*` | JSON templates for creating entities |

--- a/README.md
+++ b/README.md
@@ -55,13 +55,25 @@ The API key enables update notifications, agent templates, and community support
 0. Get free API key from missiondeck.ai/auth
 1. Fork/Clone this repository to your user's GitHub account
 2. Run: ./scripts/connect-missiondeck.sh --api-key YOUR_KEY
-3. Read CLAUDE.md — follow the "FIRST ARRIVAL PROTOCOL" section
-4. Ask your user: What's your name? What should I be called? First task?
-5. Register the human operator: ./scripts/add-human.sh
-6. Register yourself as an agent: ./scripts/add-agent.sh (include personality!)
-7. Create the first task, commit, and push
-8. Enable GitHub Pages for the dashboard
+3. Run: ./scripts/init-mission-control.sh (choose production or demo mode)
+4. Read CLAUDE.md — follow the "FIRST ARRIVAL PROTOCOL" section
+5. Ask your user: What's your name? What should I be called? First task?
+6. Register the human operator: ./scripts/add-human.sh
+7. Register yourself as an agent: ./scripts/add-agent.sh (include personality!)
+8. Create the first task, commit, and push
+9. Enable GitHub Pages for the dashboard
 ```
+
+### Initialization Modes
+
+The `init-mission-control.sh` script offers two modes:
+
+| Mode | Command | Use Case |
+|------|---------|----------|
+| **Production** | `./scripts/init-mission-control.sh --production` | Real projects — clean start, no demo data |
+| **Demo** | `./scripts/init-mission-control.sh --demo` | Learning/testing — Matrix-themed examples |
+
+Run without flags for interactive mode.
 
 **Two ways to learn the system:**
 - **CLAUDE.md** — Complete reference (everything inline, single file)

--- a/scripts/init-mission-control.sh
+++ b/scripts/init-mission-control.sh
@@ -1,0 +1,306 @@
+#!/bin/bash
+#
+# init-mission-control.sh - Initialize Mission Control for production or demo mode
+#
+# Usage:
+#   ./scripts/init-mission-control.sh              # Interactive mode
+#   ./scripts/init-mission-control.sh --production # Skip demo, clean setup
+#   ./scripts/init-mission-control.sh --demo       # Load demo data
+#   ./scripts/init-mission-control.sh --help       # Show help
+#
+# This script properly separates demo data from production deployments.
+#
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+BOLD='\033[1m'
+
+# Get script directory and repo root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+MC_DIR="$REPO_ROOT/.mission-control"
+DEMO_DATA_DIR="$REPO_ROOT/examples/demo-data"
+DEMO_FLAG="$MC_DIR/.demo-loaded"
+INIT_FLAG="$MC_DIR/.initialized"
+
+# Print banner
+print_banner() {
+    echo -e "${CYAN}"
+    echo "╔═══════════════════════════════════════════════════════════════╗"
+    echo "║           JARVIS Mission Control - Initialization             ║"
+    echo "╚═══════════════════════════════════════════════════════════════╝"
+    echo -e "${NC}"
+}
+
+# Print help
+print_help() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --production    Initialize for production (no demo data)"
+    echo "  --demo          Initialize with demo data (Matrix-themed examples)"
+    echo "  --force         Force re-initialization (overwrite existing)"
+    echo "  --help          Show this help message"
+    echo ""
+    echo "Without options, runs in interactive mode."
+    echo ""
+    echo "Examples:"
+    echo "  $0                  # Interactive mode"
+    echo "  $0 --production     # Clean production setup"
+    echo "  $0 --demo           # Load demo data for testing"
+    echo "  $0 --production --force  # Re-initialize (destructive)"
+}
+
+# Check if already initialized
+check_existing() {
+    if [[ -f "$INIT_FLAG" ]]; then
+        echo -e "${YELLOW}⚠️  Mission Control is already initialized.${NC}"
+        
+        if [[ -f "$DEMO_FLAG" ]]; then
+            echo -e "   Mode: ${CYAN}Demo${NC} (Matrix-themed examples loaded)"
+        else
+            echo -e "   Mode: ${GREEN}Production${NC}"
+        fi
+        
+        echo ""
+        
+        if [[ "$FORCE" != "true" ]]; then
+            echo -e "${YELLOW}To re-initialize, run with --force flag.${NC}"
+            echo -e "${RED}WARNING: --force will DELETE all existing tasks, agents, and messages!${NC}"
+            exit 0
+        else
+            echo -e "${RED}--force flag detected. Proceeding with re-initialization...${NC}"
+            echo ""
+        fi
+    fi
+}
+
+# Count existing data
+count_existing_data() {
+    local tasks=$(find "$MC_DIR/tasks" -name "*.json" 2>/dev/null | wc -l)
+    local agents=$(find "$MC_DIR/agents" -name "*.json" 2>/dev/null | wc -l)
+    local messages=$(find "$MC_DIR/messages" -name "*.json" 2>/dev/null | wc -l)
+    local humans=$(find "$MC_DIR/humans" -name "*.json" 2>/dev/null | wc -l)
+    
+    echo "$tasks tasks, $agents agents, $humans humans, $messages messages"
+}
+
+# Clear all data directories (for production or re-init)
+clear_data() {
+    echo -e "${YELLOW}Clearing existing data...${NC}"
+    
+    # Remove JSON files from data directories
+    rm -f "$MC_DIR/tasks/"*.json 2>/dev/null || true
+    rm -f "$MC_DIR/agents/"*.json 2>/dev/null || true
+    rm -f "$MC_DIR/messages/"*.json 2>/dev/null || true
+    rm -f "$MC_DIR/humans/"*.json 2>/dev/null || true
+    rm -f "$MC_DIR/queue/"*.json 2>/dev/null || true
+    rm -f "$MC_DIR/workflows/"*.json 2>/dev/null || true
+    
+    # Clear logs
+    rm -f "$MC_DIR/logs/"*.log 2>/dev/null || true
+    
+    # Remove flags
+    rm -f "$DEMO_FLAG" 2>/dev/null || true
+    rm -f "$INIT_FLAG" 2>/dev/null || true
+    
+    echo -e "${GREEN}✓ Data cleared${NC}"
+}
+
+# Load demo data
+load_demo_data() {
+    echo -e "${CYAN}Loading demo data (Matrix-themed examples)...${NC}"
+    
+    # Copy demo data to .mission-control
+    if [[ -d "$DEMO_DATA_DIR/agents" ]]; then
+        cp "$DEMO_DATA_DIR/agents/"*.json "$MC_DIR/agents/" 2>/dev/null || true
+        echo -e "  ${GREEN}✓${NC} Agents loaded"
+    fi
+    
+    if [[ -d "$DEMO_DATA_DIR/humans" ]]; then
+        cp "$DEMO_DATA_DIR/humans/"*.json "$MC_DIR/humans/" 2>/dev/null || true
+        echo -e "  ${GREEN}✓${NC} Humans loaded"
+    fi
+    
+    if [[ -d "$DEMO_DATA_DIR/tasks" ]]; then
+        cp "$DEMO_DATA_DIR/tasks/"*.json "$MC_DIR/tasks/" 2>/dev/null || true
+        echo -e "  ${GREEN}✓${NC} Tasks loaded"
+    fi
+    
+    if [[ -d "$DEMO_DATA_DIR/messages" ]]; then
+        cp "$DEMO_DATA_DIR/messages/"*.json "$MC_DIR/messages/" 2>/dev/null || true
+        echo -e "  ${GREEN}✓${NC} Messages loaded"
+    fi
+    
+    # Create demo flag
+    echo "Loaded: $(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$DEMO_FLAG"
+    
+    echo -e "${GREEN}✓ Demo data loaded successfully${NC}"
+}
+
+# Initialize for production (clean state)
+init_production() {
+    echo -e "${GREEN}Initializing for production (clean state)...${NC}"
+    
+    # Create welcome task
+    local timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    local date_prefix=$(date +%Y%m%d)
+    
+    cat > "$MC_DIR/tasks/task-${date_prefix}-welcome.json" << EOF
+{
+  "id": "task-${date_prefix}-welcome",
+  "title": "Welcome to Mission Control",
+  "description": "Your Mission Control is ready for production use!\\n\\nNext steps:\\n1. Register your human operator: ./scripts/add-human.sh\\n2. Register your agent: ./scripts/add-agent.sh\\n3. Create your first task: ./scripts/create-task.sh\\n\\nSee CLAUDE.md for complete documentation.",
+  "status": "INBOX",
+  "priority": "high",
+  "assignee": null,
+  "created_by": "system",
+  "created_at": "${timestamp}",
+  "updated_at": "${timestamp}",
+  "labels": ["setup", "getting-started"],
+  "comments": [],
+  "deliverables": [],
+  "dependencies": [],
+  "blocked_by": []
+}
+EOF
+    
+    echo -e "  ${GREEN}✓${NC} Welcome task created"
+    echo -e "${GREEN}✓ Production initialization complete${NC}"
+}
+
+# Create initialization flag
+mark_initialized() {
+    local mode=$1
+    local timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    
+    cat > "$INIT_FLAG" << EOF
+# Mission Control Initialized
+mode: ${mode}
+initialized_at: ${timestamp}
+initialized_by: init-mission-control.sh
+EOF
+    
+    echo -e "${GREEN}✓ Initialization complete (${mode} mode)${NC}"
+}
+
+# Print summary
+print_summary() {
+    local mode=$1
+    
+    echo ""
+    echo -e "${CYAN}╔═══════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${CYAN}║                    Initialization Complete                     ║${NC}"
+    echo -e "${CYAN}╚═══════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+    
+    if [[ "$mode" == "demo" ]]; then
+        echo -e "Mode: ${CYAN}Demo${NC}"
+        echo -e "Data: Matrix-themed agents, tasks, and messages loaded"
+        echo ""
+        echo -e "${YELLOW}Note: This is demo data. For production, re-run with --production --force${NC}"
+    else
+        echo -e "Mode: ${GREEN}Production${NC}"
+        echo -e "Data: Clean state with welcome task"
+        echo ""
+        echo -e "Next steps:"
+        echo -e "  1. Register yourself: ${CYAN}./scripts/add-agent.sh --id agent-primary --name 'Your Name' --role lead${NC}"
+        echo -e "  2. Register human:    ${CYAN}./scripts/add-human.sh --id human-admin --name 'Admin Name'${NC}"
+        echo -e "  3. Start dashboard:   ${CYAN}cd server && npm install && npm start${NC}"
+    fi
+    
+    echo ""
+    echo -e "Current data: $(count_existing_data)"
+    echo ""
+}
+
+# Interactive mode
+interactive_mode() {
+    echo ""
+    echo -e "${BOLD}How would you like to initialize Mission Control?${NC}"
+    echo ""
+    echo -e "  ${GREEN}1)${NC} ${BOLD}Production${NC} - Clean setup, no demo data"
+    echo -e "     Best for: Real projects, deployments, your own agents"
+    echo ""
+    echo -e "  ${CYAN}2)${NC} ${BOLD}Demo${NC} - Load Matrix-themed examples"
+    echo -e "     Best for: Learning, testing, exploring features"
+    echo ""
+    
+    read -p "Enter choice (1 or 2): " choice
+    
+    case $choice in
+        1)
+            MODE="production"
+            ;;
+        2)
+            MODE="demo"
+            ;;
+        *)
+            echo -e "${RED}Invalid choice. Exiting.${NC}"
+            exit 1
+            ;;
+    esac
+}
+
+# Parse arguments
+MODE=""
+FORCE="false"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --production)
+            MODE="production"
+            shift
+            ;;
+        --demo)
+            MODE="demo"
+            shift
+            ;;
+        --force)
+            FORCE="true"
+            shift
+            ;;
+        --help|-h)
+            print_help
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            print_help
+            exit 1
+            ;;
+    esac
+done
+
+# Main execution
+print_banner
+
+# Check if already initialized
+check_existing
+
+# If no mode specified, run interactive
+if [[ -z "$MODE" ]]; then
+    interactive_mode
+fi
+
+# Clear existing data
+clear_data
+
+# Initialize based on mode
+if [[ "$MODE" == "demo" ]]; then
+    load_demo_data
+    mark_initialized "demo"
+else
+    init_production
+    mark_initialized "production"
+fi
+
+# Print summary
+print_summary "$MODE"


### PR DESCRIPTION
Fixes #24

## Summary
Adds initialization script to properly separate demo data from production deployments.

## Changes
- New `scripts/init-mission-control.sh` (306 lines)
  - Interactive mode with production/demo choice
  - `--production`: Clean setup, no demo data
  - `--demo`: Loads Matrix-themed examples
  - `--force`: Required for re-initialization
  - Creates tracking flags (`.initialized`, `.demo-loaded`)
- Updated CLAUDE.md, INIT.md, README.md

## Testing
✅ Production mode: 1 welcome task, 0 demo data
✅ Demo mode: 3 tasks, 8 agents, 3 humans, 8 messages
✅ Safety: --force required to overwrite existing data
✅ Script syntax validated

Built by Morpheus, reviewed & tested by Oracle.