### PR TITLE
fix: handle url-only attachments in renderTaskAttachments

### DIFF
--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -2244,10 +2244,12 @@ function renderTaskAttachments(task) {
     }
     
     container.innerHTML = task.attachments.map(att => {
-        const pathParts = att.path.split('/');
-        const filename = pathParts[pathParts.length - 1];
-        const dir = pathParts.slice(0, -1).join('/') || 'reports';
-        const ext = filename.split('.').pop().toLowerCase();
+        // Support both path-based and url-based attachments
+        const resolvedPath = att.path || att.url || '';
+        const pathParts = resolvedPath.split('/');
+        const filename = att.name || pathParts[pathParts.length - 1] || 'file';
+        const dir = att.path ? pathParts.slice(0, -1).join('/') || 'reports' : 'reports';
+        const downloadTarget = att.path || resolvedPath;
         
         return `
             <div class="attachment-item">
@@ -2257,11 +2259,11 @@ function renderTaskAttachments(task) {
                         <polyline points="14 2 14 8 20 8"></polyline>
                     </svg>
                 </div>
-                <div class="attachment-info" onclick="openFileViewer('${escapeHtml(dir)}', '${escapeHtml(filename)}')" style="cursor: pointer; flex: 1;">
+                <div class="attachment-info" style="cursor: pointer; flex: 1;" onclick="${att.url ? `window.open('${escapeHtml(att.url)}', '_blank')` : `openFileViewer('${escapeHtml(dir)}', '${escapeHtml(filename)}')`}">
                     <div class="attachment-name">${escapeHtml(filename)}</div>
                     ${att.description ? `<div class="attachment-desc">${escapeHtml(att.description)}</div>` : ''}
                 </div>
-                <button class="btn btn-sm btn-secondary" onclick="event.stopPropagation(); downloadAttachment('${escapeHtml(att.path)}', '${escapeHtml(filename)}');" style="margin-left: auto;" title="Download">
+                <button class="btn btn-sm btn-secondary" onclick="event.stopPropagation(); ${att.url ? `window.open('${escapeHtml(att.url)}', '_blank')` : `downloadAttachment('${escapeHtml(downloadTarget)}', '${escapeHtml(filename)}')`};" style="margin-left: auto;" title="Download">
                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
                         <polyline points="7 10 12 15 17 10"></polyline>


### PR DESCRIPTION
## Bug Fix

### Problem
`renderTaskAttachments()` called `att.path.split('/')` unconditionally. When a task attachment uses `url` instead of `path`, this throws a silent `TypeError` inside `openTaskModal()`, preventing the modal from opening.

### Root Cause
Newer tasks (StoreSEO, xCloud reports) use URL-based attachments (`{url: 'https://...', name: '...'}`) but the renderer assumed `att.path` always exists.

### Fix
- `att.path` → `att.path || att.url || ''`
- Filename prefers `att.name` over URL-derived fragment
- URL attachments open in new tab via `window.open()`
- Download button handles URL-only attachments

### Testing
- Fixed locally, verified modal opens on all DONE column cards
- No breaking changes to path-based attachments

Fixes: task-20260218-mc-attachment-fix