### PR TITLE
fix: blank board crash + defensive rendering improvements (v0.9.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to JARVIS Mission Control will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.5] - 2026-02-18
+
+### Fixed
+- **Dashboard blank board — `undefined.startsWith()` crash in `getCompletedToday()`** — Tasks created with non-standard date field names (`completed` or `completed_at` instead of `updated_at`) caused a silent `TypeError` inside `getCompletedToday()` → `getMetrics()` → `renderMetrics()`, aborting `renderDashboard()` before `renderKanban()` could run. The board appeared completely empty even though the API returned all tasks correctly. Fixed by normalising the date field lookup: `(task.updated_at || task.completed_at || task.completed || '')`.
+
+### Improved
+- **`renderMetrics()` is now crash-isolated** — wrapped in try/catch so a single malformed task field can never abort the entire dashboard render again. Metric counters silently stay at 0 on error; `renderKanban()` always runs.
+- **WebSocket reconnect triggers full data reload** — If the server restarts while the dashboard is open, data now reloads automatically on WebSocket reconnect instead of staying stale/empty.
+- **Refresh button** — Added "Refresh" button next to "+ New Task" to manually force-reload all board data without a full page reload.
+- **Auto-retry on empty board** — If `init()` completes but the board has 0 tasks, an automatic retry fires after 2 seconds (guards against race condition during server restart).
+- **Last-resort recovery** — If `init()` crashes after data is loaded, a fallback attempt to render the dashboard is made so tasks already in memory are not lost.
+
 ## [0.9.4] - 2026-02-18
 
 ### Fixed

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -29,7 +29,7 @@
                 <span class="logo-icon">J</span>
                 JARVIS Mission Control
             </h1>
-            <span class="version">v0.9.4</span>
+            <span class="version">v0.9.5</span>
         </div>
         <div class="header-right">
             <div class="metrics">
@@ -50,6 +50,13 @@
                     <span class="metric-label">Agents</span>
                 </div>
             </div>
+            <button class="btn btn-secondary" id="refresh-btn" onclick="forceRefreshBoard()" title="Reload all tasks from server">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <polyline points="23 4 23 10 17 10"></polyline>
+                    <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
+                </svg>
+                Refresh
+            </button>
             <button class="btn btn-primary" onclick="openCreateTaskModal()">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <line x1="12" y1="5" x2="12" y2="19"></line>

--- a/dashboard/js/api.js
+++ b/dashboard/js/api.js
@@ -388,6 +388,8 @@ const MissionControlAPI = {
                 console.log('WebSocket connected');
                 this.wsReconnectAttempts = 0;
                 this.emit('ws.connected');
+                // Refresh data on (re)connect in case initial load missed data
+                this.emit('ws.reconnected');
             };
 
             this.ws.onclose = () => {

--- a/dashboard/js/data.js
+++ b/dashboard/js/data.js
@@ -1100,6 +1100,18 @@ class MissionControlData {
                 initDragAndDrop();
             }
         });
+
+        // Refresh data on WebSocket reconnect (handles server restart / missed initial load)
+        window.MissionControlAPI.on('ws.reconnected', async () => {
+            console.log('WebSocket reconnected — refreshing data...');
+            const loaded = await this.loadFromAPI();
+            if (loaded && typeof renderDashboard === 'function') {
+                renderDashboard();
+            }
+            if (typeof initDragAndDrop === 'function') {
+                initDragAndDrop();
+            }
+        });
     }
 
     /**
@@ -1401,7 +1413,7 @@ class MissionControlData {
         const today = new Date().toISOString().split('T')[0];
         return this.tasks.filter(task =>
             task.status === 'DONE' &&
-            task.updated_at.startsWith(today)
+            (task.updated_at || task.completed_at || task.completed || '').startsWith(today)
         ).length;
     }
 


### PR DESCRIPTION
## fix: blank board crash + defensive rendering improvements (v0.9.5)

## [0.9.5] - 2026-02-18

### Fixed
- **Dashboard blank board — `undefined.startsWith()` crash in `getCompletedToday()`** — Tasks created with non-standard date field names (`completed` or `completed_at` instead of `updated_at`) caused a silent `TypeError` inside `getCompletedToday()` → `getMetrics()` → `renderMetrics()`, aborting `renderDashboard()` before `renderKanban()` could run. The board appeared completely empty even though the API returned all tasks correctly. Fixed by normalising the date field lookup: `(task.updated_at || task.completed_at || task.completed || '')`.

### Improved
- **`renderMetrics()` is now crash-isolated** — wrapped in try/catch so a single malformed task field can never abort the entire dashboard render again. Metric counters silently stay at 0 on error; `renderKanban()` always runs.
- **WebSocket reconnect triggers full data reload** — If the server restarts while the dashboard is open, data now reloads automatically on WebSocket reconnect instead of staying stale/empty.
- **Refresh button** — Added "Refresh" button next to "+ New Task" to manually force-reload all board data without a full page reload.
- **Auto-retry on empty board** — If `init()` completes but the board has 0 tasks, an automatic retry fires after 2 seconds (guards against race condition during server restart).
- **Last-resort recovery** — If `init()` crashes after data is loaded, a fallback attempt to render the dashboard is made so tasks already in memory are not lost.

---

### Files Changed
- `dashboard/js/data.js` — `getCompletedToday()` undefined field access fix
- `dashboard/js/app.js` — `renderMetrics()` try/catch; `forceRefreshBoard()`; auto-retry; ws.reconnected handler
- `dashboard/js/api.js` — emit `ws.reconnected` on WebSocket open
- `dashboard/index.html` — version bump v0.9.4 → v0.9.5, Refresh button added
- `CHANGELOG.md` — v0.9.5 entry

See CHANGELOG.md [0.9.5] section for full details.
