### PR TITLE
release: v1.0.0 — mc CLI, MissionDeck Cloud, subtasks, deliverables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to JARVIS Mission Control will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-02-18
+
+### 🎉 First Stable Release
+
+JARVIS Mission Control reaches v1.0.0 — production-ready, battle-tested multi-agent coordination platform.
+
+### Added
+- **`mc` CLI — Agent Command-Line Interface** (inspired by [Clawe](https://github.com/getclawe/clawe))
+  - Full task management from command line: `mc task:status`, `mc task:comment`, `mc task:create`, `mc task:done`
+  - Subtask management: `mc subtask:add`, `mc subtask:check`, `mc subtask:list`
+  - Deliverables: `mc deliver "name" --path ./file`
+  - Squad visibility: `mc squad`, `mc feed`, `mc check`
+  - Agent status: `mc agent:status active|busy|idle`
+  - Notifications: `mc notify "message"`
+  - MissionDeck Cloud mode: auto-detects `.missiondeck` config, switches API target
+  - `mc status` — shows connected mode (local / cloud) + dashboard URL
+  - Zero external dependencies — Node.js stdlib only
+- **MissionDeck Cloud Integration** — Host your dashboard at `missiondeck.ai/workspace/:slug`
+  - `scripts/connect-missiondeck.sh` — one-command setup wizard
+  - `server/missiondeck-sync.js` — auto-syncs tasks to cloud on every change
+  - Supabase edge functions `mc-sync` and `mc-api` for cloud API
+  - Access control: Public / Passcode (Matrix lock screen) / Authenticated / Private
+- **Subtasks & Deliverables** — richer task schema for complex work
+- **MissionDeck Cloud UI** at `missiondeck.ai/workspace/:slug`, `missiondeck.ai/settings/workspaces`
+- **`scripts/mc-install.sh`** — one-command global install (`ln -sf` to `/usr/local/bin/mc`)
+
+### Deprecated
+- `scripts/jarvis.js` and `scripts/jarvis-install.sh` — superseded by `scripts/mc` and `scripts/mc-install.sh`
+
+### Milestone: 1.0.0 Release Criteria
+- [x] Core Kanban board stable
+- [x] Multi-agent support (5 agents: Oracle, Tank, Morpheus, Shuri, Keymaker)
+- [x] WebSocket real-time updates
+- [x] Defensive rendering (blank board crash resolved)
+- [x] Deployment safety (safe-deploy.sh, automated backups)
+- [x] mc CLI for agent command-line access
+- [x] MissionDeck Cloud hosting option
+- [x] CHANGELOG complete from v0.1.0
+
 ## [0.10.0] - 2026-02-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JARVIS Mission Control for OpenClaw
 
-[![Version](https://img.shields.io/badge/version-0.9.4-brightgreen.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.0.0-brightgreen.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](LICENSE)
 
 A robust, Git-based Mission Control system for orchestrating AI agents and human collaborators. Designed to be adopted by agents themselves and built collaboratively.
@@ -202,6 +202,32 @@ cp examples/demo-data/tasks/*.json .mission-control/tasks/
 5. Start the server: cd server && npm install && npm start
 6. Never modify the original template repository
 ```
+
+## 🖥️ Agent CLI (`mc`)
+
+Agents can manage tasks directly from the command line — no curl, no JSON editing.
+
+```bash
+# Install globally
+./scripts/mc-install.sh
+
+# Common commands
+mc check                           # My pending tasks
+mc tasks --status IN_PROGRESS      # Filter tasks
+mc task:status task-123 DONE       # Update status
+mc task:comment task-123 "Done ✓"  # Add comment
+mc task:create --title "Fix auth"  # Create task
+mc squad                           # All agent statuses
+mc deliver task-123 "Report" --path ./report.md
+mc subtask:add task-123 "Write tests"
+mc subtask:check task-123 0
+mc subtask:list task-123
+mc status                          # Show connection mode
+```
+
+Works in **local mode** (hits `localhost:3000`) or **cloud mode** (auto-detects `.missiondeck` config and hits `missiondeck.ai`).
+
+> Inspired by [Clawe](https://github.com/getclawe/clawe) — multi-agent coordination for OpenClaw.
 
 ## Project Structure
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -29,7 +29,7 @@
                 <span class="logo-icon">J</span>
                 JARVIS Mission Control
             </h1>
-            <span class="version">v0.9.5</span>
+            <span class="version">v1.0.0</span>
         </div>
         <div class="header-right">
             <div class="metrics">

--- a/scripts/jarvis-install.sh
+++ b/scripts/jarvis-install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# DEPRECATED — Use scripts/mc-install.sh instead. Superseded by v1.0.0 mc CLI.
 # jarvis-install.sh — Install jarvis CLI globally via symlink
 # Run from any directory: bash /path/to/scripts/jarvis-install.sh
 

--- a/scripts/jarvis.js
+++ b/scripts/jarvis.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 /**
+ * DEPRECATED — Use `mc` instead (scripts/mc). This file is superseded by v1.0.0.
  * JARVIS CLI — Agent command-line interface for JARVIS Mission Control
  * Inspired by clawe (https://github.com/getclawe/clawe)
  *

--- a/scripts/mc
+++ b/scripts/mc
@@ -18,6 +18,10 @@
  *   mc squad                       (show all agents + statuses)
  *   mc feed                        (recent activity)
  *   mc check                       (my pending tasks)
+ *   mc status                      (show connection mode + dashboard URL)
+ *   mc subtask:add <id> "<text>"   (add subtask to task)
+ *   mc subtask:check <id> <index>  (toggle subtask done at index)
+ *   mc subtask:list <id>           (list subtasks with checkboxes)
  */
 
 const http = require('http');
@@ -40,10 +44,34 @@ function detectAgentId() {
   return os.hostname().split('-')[0].toLowerCase();
 }
 
+// ── MissionDeck Cloud config ─────────────────────────────────────────────
+function loadMissionDeckConfig() {
+  const mcDir = path.resolve(__dirname, '..');
+  const envFile = path.join(mcDir, '.missiondeck');
+  if (fs.existsSync(envFile)) {
+    fs.readFileSync(envFile, 'utf8').split('\n').forEach(line => {
+      const eq = line.indexOf('=');
+      if (eq > 0 && !line.startsWith('#')) {
+        const k = line.slice(0, eq).trim();
+        const v = line.slice(eq + 1).trim();
+        if (k && !process.env[k]) process.env[k] = v;
+      }
+    });
+  }
+  const apiKey = process.env.MISSIONDECK_API_KEY;
+  const slug = process.env.MISSIONDECK_SLUG;
+  const base = process.env.MISSIONDECK_URL || 'https://missiondeck.ai';
+  if (apiKey && slug) {
+    return { mode: 'cloud', baseUrl: `${base}/functions/v1/mc-api/${slug}`, headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' }, dashboardUrl: `${base}/workspace/${slug}` };
+  }
+  return { mode: 'local', baseUrl: process.env.MC_SERVER_URL || SERVER_URL, headers: { 'Content-Type': 'application/json' }, dashboardUrl: SERVER_URL };
+}
+const CONFIG = loadMissionDeckConfig();
+
 // ── HTTP helper ─────────────────────────────────────────────────────────────
 function request(method, urlPath, body) {
   return new Promise((resolve, reject) => {
-    const url = new URL(SERVER_URL + urlPath);
+    const url = new URL(CONFIG.baseUrl + urlPath);
     const lib = url.protocol === 'https:' ? https : http;
     const data = body ? JSON.stringify(body) : null;
 
@@ -53,7 +81,7 @@ function request(method, urlPath, body) {
       path: url.pathname + url.search,
       method,
       headers: {
-        'Content-Type': 'application/json',
+        ...CONFIG.headers,
         ...(data ? { 'Content-Length': Buffer.byteLength(data) } : {})
       }
     }, (res) => {
@@ -443,6 +471,105 @@ async function cmdCheck(args) {
   }
 }
 
+async function cmdStatus(_args) {
+  if (CONFIG.mode === 'cloud') {
+    const slug = process.env.MISSIONDECK_SLUG || '?';
+    let taskCount = '?';
+    try {
+      const res = await GET('/api/tasks');
+      if (res.status === 200 && Array.isArray(res.body)) taskCount = res.body.length;
+    } catch (_) {}
+    console.log(`\n${C.bold}Mission Control${C.reset}\n`);
+    console.log(`  Mode:      ${C.cyan}☁️  MissionDeck Cloud${C.reset}`);
+    console.log(`  Workspace: ${C.blue}${CONFIG.dashboardUrl}${C.reset}`);
+    console.log(`  Tasks:     ${taskCount} total`);
+    console.log(`  Slug:      ${slug}`);
+  } else {
+    let taskCount = '?';
+    try {
+      const res = await GET('/api/tasks');
+      if (res.status === 200 && Array.isArray(res.body)) taskCount = res.body.length;
+    } catch (_) {}
+    console.log(`\n${C.bold}Mission Control${C.reset}\n`);
+    console.log(`  Mode:      ${C.yellow}🖥️  Local${C.reset}`);
+    console.log(`  Dashboard: ${C.blue}${CONFIG.dashboardUrl}${C.reset}`);
+    console.log(`  Tasks:     ${taskCount} total`);
+  }
+  console.log('');
+}
+
+// ── Subtask helpers ───────────────────────────────────────────────────────────
+function findTaskFile(idOrSuffix) {
+  const tasksDir = path.join(__dirname, '..', '.mission-control', 'tasks');
+  if (!fs.existsSync(tasksDir)) return null;
+  // Exact match first
+  const exact = path.join(tasksDir, `${idOrSuffix}.json`);
+  if (fs.existsSync(exact)) return exact;
+  // Suffix match
+  const files = fs.readdirSync(tasksDir).filter(f => f.endsWith('.json'));
+  const match = files.find(f => f.replace('.json','').endsWith(idOrSuffix));
+  return match ? path.join(tasksDir, match) : null;
+}
+
+async function cmdSubtaskAdd(args) {
+  const id = args[0];
+  const text = args.slice(1).join(' ').replace(/^["']|["']$/g, '');
+  if (!id || !text) {
+    console.error('Usage: mc subtask:add <task_id> "<description>"'); process.exit(1);
+  }
+  const taskFile = findTaskFile(id);
+  if (!taskFile) { console.error(`Task not found: ${id}`); process.exit(1); }
+  const task = JSON.parse(fs.readFileSync(taskFile, 'utf8'));
+  if (!Array.isArray(task.subtasks)) task.subtasks = [];
+  task.subtasks.push({ text, done: false });
+  task.updated_at = timestamp();
+  fs.writeFileSync(taskFile, JSON.stringify(task, null, 2));
+  const idx = task.subtasks.length - 1;
+  console.log(`${C.green}✓${C.reset} Subtask [${idx}] added to ${C.dim}${task.id}${C.reset}`);
+  console.log(`  ${C.dim}☐${C.reset} ${text}`);
+}
+
+async function cmdSubtaskCheck(args) {
+  const id = args[0];
+  const index = parseInt(args[1], 10);
+  if (!id || isNaN(index)) {
+    console.error('Usage: mc subtask:check <task_id> <index>'); process.exit(1);
+  }
+  const taskFile = findTaskFile(id);
+  if (!taskFile) { console.error(`Task not found: ${id}`); process.exit(1); }
+  const task = JSON.parse(fs.readFileSync(taskFile, 'utf8'));
+  if (!Array.isArray(task.subtasks) || !task.subtasks[index]) {
+    console.error(`Subtask index ${index} not found (task has ${(task.subtasks||[]).length} subtasks)`);
+    process.exit(1);
+  }
+  task.subtasks[index].done = !task.subtasks[index].done;
+  task.updated_at = timestamp();
+  fs.writeFileSync(taskFile, JSON.stringify(task, null, 2));
+  const sub = task.subtasks[index];
+  const mark = sub.done ? `${C.green}☑${C.reset}` : `${C.dim}☐${C.reset}`;
+  console.log(`${C.green}✓${C.reset} Subtask [${index}] → ${sub.done ? 'done' : 'undone'}`);
+  console.log(`  ${mark} ${sub.text}`);
+}
+
+async function cmdSubtaskList(args) {
+  const id = args[0];
+  if (!id) { console.error('Usage: mc subtask:list <task_id>'); process.exit(1); }
+  const taskFile = findTaskFile(id);
+  if (!taskFile) { console.error(`Task not found: ${id}`); process.exit(1); }
+  const task = JSON.parse(fs.readFileSync(taskFile, 'utf8'));
+  const subtasks = task.subtasks || [];
+  if (!subtasks.length) {
+    console.log(`${C.dim}No subtasks for ${task.id}${C.reset}`); return;
+  }
+  const done = subtasks.filter(s => s.done).length;
+  console.log(`\n${C.bold}Subtasks${C.reset} — ${task.title} (${done}/${subtasks.length} done)\n`);
+  subtasks.forEach((s, i) => {
+    const mark = s.done ? `${C.green}☑${C.reset}` : `${C.dim}☐${C.reset}`;
+    console.log(`  [${i}] ${mark}  ${s.done ? C.dim : ''}${s.text}${C.reset}`);
+  });
+  console.log('');
+}
+
 function printHelp() {
   console.log(`
 ${C.bold}mc${C.reset} — Mission Control CLI for AI Agents
@@ -460,15 +587,23 @@ ${C.bold}Agent Commands:${C.reset}
   mc agent:status <active|busy|idle|offline>
   mc squad
 
+${C.bold}Subtask Commands:${C.reset}
+  mc subtask:add <id> "<description>"
+  mc subtask:check <id> <index>
+  mc subtask:list <id>
+
 ${C.bold}Team Commands:${C.reset}
   mc notify "<message>"
   mc deliver "<title>" --path <file>
   mc feed
   mc check
+  mc status
 
 ${C.bold}Environment:${C.reset}
-  MC_SERVER_URL   Server URL (default: http://localhost:3000)
-  MC_AGENT_ID     Your agent ID (default: auto-detected)
+  MC_SERVER_URL         Server URL (default: http://localhost:3000)
+  MC_AGENT_ID           Your agent ID (default: auto-detected)
+  MISSIONDECK_API_KEY   MissionDeck Cloud API key (auto-loaded from .missiondeck)
+  MISSIONDECK_SLUG      Your workspace slug
 
 ${C.bold}Examples:${C.reset}
   mc check
@@ -484,21 +619,25 @@ ${C.bold}Examples:${C.reset}
 const [,, cmd, ...args] = process.argv;
 
 const commands = {
-  'tasks':         cmdTasks,
-  'task:view':     cmdTaskView,
-  'task:status':   cmdTaskStatus,
-  'task:comment':  cmdTaskComment,
-  'task:create':   cmdTaskCreate,
-  'task:done':     cmdTaskDone,
-  'agent:status':  cmdAgentStatus,
-  'notify':        cmdNotify,
-  'deliver':       cmdDeliver,
-  'squad':         cmdSquad,
-  'feed':          cmdFeed,
-  'check':         cmdCheck,
-  'help':          async () => printHelp(),
-  '--help':        async () => printHelp(),
-  '-h':            async () => printHelp(),
+  'tasks':          cmdTasks,
+  'task:view':      cmdTaskView,
+  'task:status':    cmdTaskStatus,
+  'task:comment':   cmdTaskComment,
+  'task:create':    cmdTaskCreate,
+  'task:done':      cmdTaskDone,
+  'agent:status':   cmdAgentStatus,
+  'notify':         cmdNotify,
+  'deliver':        cmdDeliver,
+  'squad':          cmdSquad,
+  'feed':           cmdFeed,
+  'check':          cmdCheck,
+  'status':         cmdStatus,
+  'subtask:add':    cmdSubtaskAdd,
+  'subtask:check':  cmdSubtaskCheck,
+  'subtask:list':   cmdSubtaskList,
+  'help':           async () => printHelp(),
+  '--help':         async () => printHelp(),
+  '-h':             async () => printHelp(),
 };
 
 if (!cmd || !commands[cmd]) {

--- a/scripts/mc-install.sh
+++ b/scripts/mc-install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+MC_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ln -sf "$MC_DIR/scripts/mc" /usr/local/bin/mc
+echo "✅ mc installed to /usr/local/bin/mc"
+echo "   Run: mc --help"


### PR DESCRIPTION
## v1.0.0 — First Stable Release

First stable release. See CHANGELOG.md for full details.

### Changes in this PR
- **`scripts/mc`** enhanced with MissionDeck Cloud auto-config, `mc status`, `mc subtask:add/check/list`
- **`scripts/mc-install.sh`** added — global install via symlink
- **`CHANGELOG.md`** — v1.0.0 entry prepended
- **`README.md`** — version badge updated to 1.0.0, Agent CLI section added
- **`dashboard/index.html`** — version display updated to v1.0.0
- **`scripts/jarvis.js` / `jarvis-install.sh`** — marked deprecated (superseded by mc)

Closes #36 (superseded).