### PR TITLE
fix: mc agent auto-detection for root-level workspaces

### DIFF
--- a/scripts/mc
+++ b/scripts/mc
@@ -36,11 +36,17 @@ const AGENT_ID   = process.env.MC_AGENT_ID   || detectAgentId();
 const TELEGRAM_CHAT = process.env.MC_TELEGRAM_CHAT || '-5117663765';
 
 function detectAgentId() {
-  // Try to detect from workspace path
+  // 1. Check .mc-agent file in cwd (for agents whose workspace is root-level)
+  const mcAgentFile = path.join(process.cwd(), '.mc-agent');
+  if (fs.existsSync(mcAgentFile)) {
+    const id = fs.readFileSync(mcAgentFile, 'utf8').trim();
+    if (id) return id;
+  }
+  // 2. Try to detect from workspace path (e.g. /agents/morpheus/)
   const cwd = process.cwd();
   const match = cwd.match(/agents\/([^/]+)/);
   if (match) return match[1];
-  // Fall back to hostname
+  // 3. Fall back to hostname
   return os.hostname().split('-')[0].toLowerCase();
 }
 


### PR DESCRIPTION
Adds `.mc-agent` file support so agents whose workspace is at the root level (like Oracle) are correctly identified without needing `MC_AGENT_ID` env var.