### PR TITLE
fix: block SSRF via webhook URL validation (v1.0.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [1.0.10] - 2026-03-02
+
+### Security — CRITICAL FIX (PR #45)
+- **SSRF via Webhook Registration** (server/index.js) — HIGH SEVERITY
+  - Added `validateWebhookUrl()` to block Server-Side Request Forgery attacks
+  - Blocks: localhost/127.0.0.1/::1/0.0.0.0
+  - Blocks: Private IPv4 (10.x, 172.16-31.x, 192.168.x, 100.64-127.x CGNAT)
+  - Blocks: AWS EC2 + GCP metadata endpoints (169.254.169.254, metadata.google.internal)
+  - Blocks: APIPA/link-local ranges (169.254.x.x)
+  - Blocks: Private IPv6 (fc::/7, fe80::/10, ::1, ::ffff:)
+  - Blocks: Reserved test ranges (192.0.2.x, 198.51.100.x, 203.0.113.x)
+  - Blocks: Non-HTTP(S) protocols (file://, ftp://, etc.)
+  - Returns HTTP 400 with descriptive error on blocked URLs
+  - Identified by Morpheus (Security Counsel) in post-v1.0.9 audit
+
 ## [v1.0.9] - 2026-03-02
 ### Security
 - Fixed 47 XSS vulnerabilities in dashboard/js/app.js — all innerHTML assignments now sanitized via DOMPurify

--- a/server/index.js
+++ b/server/index.js
@@ -867,11 +867,80 @@ app.get('/api/webhooks', (req, res) => {
     res.json(list);
 });
 
+/**
+ * Validates a webhook URL against SSRF attack vectors.
+ * Blocks: private IPs, localhost, APIPA, AWS/cloud metadata, non-HTTP(S) schemes.
+ * @param {string} urlString
+ * @returns {{ valid: boolean, reason?: string }}
+ */
+function validateWebhookUrl(urlString) {
+    let parsed;
+    try {
+        parsed = new URL(urlString);
+    } catch {
+        return { valid: false, reason: 'Invalid URL format' };
+    }
+
+    // Only allow http and https
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+        return { valid: false, reason: `Protocol '${parsed.protocol}' is not allowed. Use http or https.` };
+    }
+
+    const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+
+    // Block localhost variants
+    const blocked = ['localhost', '127.0.0.1', '::1', '0.0.0.0', '0000:0000:0000:0000:0000:0000:0000:0001'];
+    if (blocked.includes(hostname)) {
+        return { valid: false, reason: 'Localhost addresses are not allowed' };
+    }
+
+    // Block AWS EC2 and GCP metadata endpoints
+    if (hostname === '169.254.169.254' || hostname === 'metadata.google.internal') {
+        return { valid: false, reason: 'Cloud metadata endpoints are not allowed' };
+    }
+
+    // Block private and reserved IPv4 ranges
+    const privateRanges = [
+        /^127\./, // loopback
+        /^10\./, // RFC1918
+        /^172\.(1[6-9]|2\d|3[01])\./, // RFC1918
+        /^192\.168\./, // RFC1918
+        /^169\.254\./, // APIPA / link-local
+        /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./, // CGNAT RFC6598
+        /^192\.0\.2\./, // TEST-NET-1
+        /^198\.51\.100\./, // TEST-NET-2
+        /^203\.0\.113\./, // TEST-NET-3
+    ];
+    for (const pattern of privateRanges) {
+        if (pattern.test(hostname)) {
+            return { valid: false, reason: 'Private or reserved IP ranges are not allowed' };
+        }
+    }
+
+    // Block private IPv6 ranges
+    if (
+        hostname === '::1' ||
+        hostname.startsWith('fc') ||
+        hostname.startsWith('fd') ||
+        hostname.startsWith('fe80') ||
+        hostname.startsWith('::ffff:')
+    ) {
+        return { valid: false, reason: 'Private or link-local IPv6 addresses are not allowed' };
+    }
+
+    return { valid: true };
+}
+
 app.post('/api/webhooks', (req, res) => {
     const { id, url, events } = req.body;
 
     if (!id || !url || !events) {
         return res.status(400).json({ error: 'Missing required fields: id, url, events' });
+    }
+
+    const urlCheck = validateWebhookUrl(url);
+    if (!urlCheck.valid) {
+        return res.status(400).json({ error: `Invalid webhook URL: ${urlCheck.reason}` });
     }
 
     registerWebhook(id, url, events);

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jarvis-mission-control-server",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Backend server for JARVIS Mission Control - handles data persistence, real-time updates, and OpenClaw agent integration",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## 🔴 Security Fix — SSRF via Webhook Registration

**Severity:** HIGH  
**Found by:** Morpheus (Security Counsel), post-v1.0.9 audit  
**Fixes:** Server-Side Request Forgery (SSRF) at `server/index.js` POST `/api/webhooks`

---

### Problem

The webhook registration endpoint accepted any URL without validation. An attacker could register a webhook pointing to internal/private URLs, causing the server to make outbound requests on their behalf when events fire.

```bash
# This worked — server would hit localhost:22 on any event
POST /api/webhooks
{"id":"evil","url":"http://localhost:22","events":["*"]}

# AWS metadata exfiltration
{"url":"http://169.254.169.254/latest/meta-data/iam/security-credentials/"}
```

---

### Fix

Added `validateWebhookUrl()` called before `registerWebhook()`. Blocks:

| Category | Examples |
|----------|---------|
| Localhost | `localhost`, `127.0.0.1`, `::1`, `0.0.0.0` |
| Private IPv4 | `10.x`, `172.16-31.x`, `192.168.x` |
| CGNAT | `100.64-127.x` (RFC6598) |
| Cloud metadata | `169.254.169.254`, `metadata.google.internal` |
| APIPA/link-local | `169.254.x.x`, `fe80::/10` |
| Private IPv6 | `fc::/7`, `fd::/8`, `::ffff:` |
| Reserved ranges | `192.0.2.x`, `198.51.100.x`, `203.0.113.x` |
| Non-HTTP(S) | `file://`, `ftp://`, `dict://`, etc. |

Returns **HTTP 400** with a descriptive error message on any blocked URL.

---

### Files Changed
- `server/index.js` — `validateWebhookUrl()` function + integrated into POST handler
- `server/package.json` — bumped to `1.0.10`
- `CHANGELOG.md` — documented fix

---

**Ready for Morpheus security review.** 🛡️