### PR TITLE
feat: Claude Code session tracking (v1.2.0)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -29,7 +29,7 @@
                 <span class="logo-icon">J</span>
                 JARVIS Mission Control
             </h1>
-            <span class="version">v1.1.0</span>
+            <span class="version">v1.2.0</span>
         </div>
         <div class="header-right">
             <div class="metrics">
@@ -104,6 +104,20 @@
                 </div>
                 <div class="agents-list" id="agents-list">
                     <!-- Agents will be populated by JavaScript -->
+                </div>
+            </div>
+
+            <!-- Claude Sessions Section (v1.2.0) -->
+            <div class="sidebar-section">
+                <div class="sidebar-header" style="cursor:pointer;" onclick="openClaudeSessions()" title="View Claude Code Sessions">
+                    <h2 class="sidebar-title">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <rect x="2" y="3" width="20" height="14" rx="2"></rect>
+                            <path d="M8 21h8m-4-4v4"></path>
+                        </svg>
+                        Claude Sessions
+                    </h2>
+                    <p class="sidebar-subtitle" id="claude-sessions-subtitle">Loading…</p>
                 </div>
             </div>
         </aside>
@@ -1096,9 +1110,26 @@
         </div>
     </div>
 
+    <!-- Claude Sessions Panel (v1.2.0) -->
+    <div class="agent-profile-panel" id="claude-sessions-panel" style="display:none; width:520px; max-width:95vw;">
+        <div class="profile-panel-header" style="display:flex; align-items:center; gap:10px; padding:16px 20px;">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="color:#7c3aed; flex-shrink:0;">
+                <rect x="2" y="3" width="20" height="14" rx="2"></rect>
+                <path d="M8 21h8m-4-4v4"></path>
+            </svg>
+            <span style="font-weight:600; font-size:15px; flex:1;">Claude Code Sessions</span>
+            <button class="close-btn profile-close" onclick="closeClaudeSessions()" aria-label="Close" style="margin-left:auto;">&times;</button>
+        </div>
+        <div class="profile-panel-body" style="padding:0 20px 20px;">
+            <div id="claude-sessions-meta" style="font-size:12px; color:var(--text-muted); margin-bottom:14px; display:flex; gap:16px; flex-wrap:wrap;"></div>
+            <div id="claude-sessions-list"></div>
+        </div>
+    </div>
+
     <script src="./js/api.js"></script>
     <script src="./js/data.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
     <script src="./js/app.js"></script>
+    <script src="./js/claude-sessions.js"></script>
 </body>
 </html>

--- a/dashboard/js/claude-sessions.js
+++ b/dashboard/js/claude-sessions.js
@@ -1,0 +1,187 @@
+/**
+ * Claude Code Sessions Panel — JARVIS Mission Control v1.2.0
+ * Displays auto-discovered Claude Code sessions with token usage and cost info.
+ */
+
+let claudeSessionsData = null;
+
+// ── Sidebar badge refresh (runs on normal poll cycle) ──────────────────────
+async function refreshClaudeSessionsBadge() {
+    try {
+        const res = await fetch('/api/claude/sessions');
+        if (!res.ok) return;
+        const data = await res.json();
+        claudeSessionsData = data;
+        const sub = document.getElementById('claude-sessions-subtitle');
+        if (sub) {
+            const activeCount = data.activeCount || 0;
+            const total = data.total || 0;
+            sub.textContent = activeCount > 0
+                ? `${activeCount} active · ${total} total`
+                : `${total} session${total !== 1 ? 's' : ''}`;
+        }
+    } catch (_) {}
+}
+
+// Call once on page load and every 60s
+refreshClaudeSessionsBadge();
+setInterval(refreshClaudeSessionsBadge, 60_000);
+
+// ── Panel open/close ───────────────────────────────────────────────────────
+async function openClaudeSessions() {
+    const panel = document.getElementById('claude-sessions-panel');
+    if (!panel) return;
+    panel.style.display = 'flex';
+    panel.style.flexDirection = 'column';
+    panel.classList.add('open');
+    await loadClaudeSessionsPanel();
+}
+
+function closeClaudeSessions() {
+    const panel = document.getElementById('claude-sessions-panel');
+    if (panel) {
+        panel.classList.remove('open');
+        panel.style.display = 'none';
+    }
+}
+
+// ── Panel content ──────────────────────────────────────────────────────────
+async function loadClaudeSessionsPanel(forceRescan = false) {
+    const listEl = document.getElementById('claude-sessions-list');
+    const metaEl = document.getElementById('claude-sessions-meta');
+    if (!listEl) return;
+
+    listEl.innerHTML = '<div style="color:var(--text-muted); font-size:13px; padding:20px 0;">Scanning sessions…</div>';
+
+    try {
+        const url = forceRescan ? '/api/claude/sessions?scan=1' : '/api/claude/sessions';
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        claudeSessionsData = data;
+
+        // Meta bar
+        if (metaEl) {
+            const lastScan = data.lastScan ? new Date(data.lastScan).toLocaleTimeString() : 'never';
+            metaEl.innerHTML = `
+                <span>📁 ${DOMPurify.sanitize(data.projectsDir || '~/.claude/projects')}</span>
+                <span>🕐 Last scan: ${DOMPurify.sanitize(lastScan)}</span>
+                <span style="cursor:pointer; color:var(--accent);" onclick="loadClaudeSessionsPanel(true)" title="Force rescan">↻ Rescan</span>
+            `;
+        }
+
+        if (!data.sessions || data.sessions.length === 0) {
+            listEl.innerHTML = `
+                <div style="text-align:center; padding:32px 16px; color:var(--text-muted);">
+                    <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="margin-bottom:12px; opacity:0.4;">
+                        <rect x="2" y="3" width="20" height="14" rx="2"></rect>
+                        <path d="M8 21h8m-4-4v4"></path>
+                    </svg>
+                    <p style="margin:0 0 6px; font-weight:500;">No Claude Code sessions found</p>
+                    <p style="margin:0; font-size:12px;">Sessions appear here when Claude Code is run locally.<br>Looking in: ${DOMPurify.sanitize(data.projectsDir || '~/.claude/projects')}</p>
+                </div>`;
+            return;
+        }
+
+        listEl.innerHTML = data.sessions.map(s => renderSessionCard(s)).join('');
+
+    } catch (err) {
+        listEl.innerHTML = `<div style="color:#ef4444; font-size:13px; padding:12px 0;">Error loading sessions: ${DOMPurify.sanitize(err.message)}</div>`;
+    }
+}
+
+function renderSessionCard(s) {
+    const isActive = s.active;
+    const activeDot = isActive
+        ? `<span style="display:inline-block; width:8px; height:8px; border-radius:50%; background:#22c55e; margin-right:6px; flex-shrink:0;"></span>`
+        : `<span style="display:inline-block; width:8px; height:8px; border-radius:50%; background:var(--text-muted); margin-right:6px; flex-shrink:0; opacity:0.4;"></span>`;
+
+    const project = s.project || s.projectDir || 'Unknown';
+    const projectShort = project.length > 40 ? '…' + project.slice(-37) : project;
+
+    const lastSeen = s.lastSeen
+        ? timeAgo(new Date(s.lastSeen))
+        : 'never';
+
+    const totalTokens = s.tokens ? formatTokens(s.tokens.total) : '—';
+    const inputTokens = s.tokens ? formatTokens(s.tokens.input) : '—';
+    const outputTokens = s.tokens ? formatTokens(s.tokens.output) : '—';
+    const cost = s.cost && s.cost.estimated > 0
+        ? `$${s.cost.estimated.toFixed(4)}`
+        : s.tokens && s.tokens.total === 0 ? '$0.00' : '—';
+
+    const model = s.model && s.model !== 'unknown' ? s.model : null;
+    const branch = s.gitBranch || null;
+
+    const errorBadge = s.hasError
+        ? `<span style="background:#7f1d1d; color:#fca5a5; font-size:10px; padding:1px 6px; border-radius:4px; margin-left:6px;">error</span>`
+        : '';
+
+    return `
+    <div style="
+        border: 1px solid var(--border-color, #2d2d2d);
+        border-radius: 8px;
+        padding: 14px;
+        margin-bottom: 10px;
+        background: var(--card-bg, #1a1a1a);
+        ${isActive ? 'border-left: 3px solid #22c55e;' : ''}
+    ">
+        <div style="display:flex; align-items:center; margin-bottom:8px;">
+            ${activeDot}
+            <span style="font-size:12px; font-weight:600; flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${DOMPurify.sanitize(project)}">${DOMPurify.sanitize(projectShort)}</span>
+            ${errorBadge}
+            <span style="font-size:11px; color:var(--text-muted); white-space:nowrap; margin-left:8px;">${DOMPurify.sanitize(lastSeen)}</span>
+        </div>
+
+        <div style="font-size:11px; color:var(--text-muted); margin-bottom:10px; font-family:monospace; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">
+            ${DOMPurify.sanitize(s.sessionId)}
+        </div>
+
+        ${model || branch ? `
+        <div style="display:flex; gap:6px; flex-wrap:wrap; margin-bottom:10px;">
+            ${model ? `<span style="background:var(--bg-secondary,#252525); border:1px solid var(--border-color,#2d2d2d); color:#a78bfa; font-size:10px; padding:2px 7px; border-radius:4px;">🤖 ${DOMPurify.sanitize(model)}</span>` : ''}
+            ${branch ? `<span style="background:var(--bg-secondary,#252525); border:1px solid var(--border-color,#2d2d2d); color:#60a5fa; font-size:10px; padding:2px 7px; border-radius:4px;">⎇ ${DOMPurify.sanitize(branch)}</span>` : ''}
+        </div>` : ''}
+
+        <div style="display:grid; grid-template-columns:1fr 1fr 1fr 1fr; gap:8px;">
+            ${statChip('💬', 'Messages', String(s.messageCount || 0))}
+            ${statChip('⬆', 'Input', inputTokens)}
+            ${statChip('⬇', 'Output', outputTokens)}
+            ${statChip('💰', 'Cost', cost)}
+        </div>
+
+        ${s.hasError && s.lastError ? `
+        <div style="margin-top:8px; font-size:11px; color:#fca5a5; background:#1c0a0a; border:1px solid #7f1d1d; border-radius:4px; padding:6px 8px;">
+            ⚠ ${DOMPurify.sanitize(String(s.lastError))}
+        </div>` : ''}
+    </div>`;
+}
+
+function statChip(icon, label, value) {
+    return `
+    <div style="background:var(--bg-secondary,#252525); border:1px solid var(--border-color,#2d2d2d); border-radius:6px; padding:6px 8px; text-align:center;">
+        <div style="font-size:11px; color:var(--text-muted); margin-bottom:2px;">${icon} ${label}</div>
+        <div style="font-size:13px; font-weight:600;">${DOMPurify.sanitize(value)}</div>
+    </div>`;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+function formatTokens(n) {
+    if (!n || n === 0) return '0';
+    if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+    if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+    return String(n);
+}
+
+function timeAgo(date) {
+    const now = Date.now();
+    const diff = now - date.getTime();
+    const secs = Math.floor(diff / 1000);
+    if (secs < 60) return 'just now';
+    const mins = Math.floor(secs / 60);
+    if (mins < 60) return `${mins}m ago`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs}h ago`;
+    const days = Math.floor(hrs / 24);
+    return `${days}d ago`;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jarvis-mission-control",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "JARVIS Mission Control — agent task management system with CLI",
   "bin": {
     "jarvis": "./scripts/jarvis.js"

--- a/server/claude-sessions.js
+++ b/server/claude-sessions.js
@@ -1,0 +1,320 @@
+/**
+ * Claude Code Session Scanner
+ *
+ * Auto-discovers local Claude Code sessions by scanning ~/.claude/projects/.
+ * Extracts token usage, model info, message counts, cost estimates, and active status
+ * from JSONL transcripts. Scans every 60 seconds via background scheduler.
+ *
+ * v1.2.0 feature — Week 2, Task 1
+ */
+
+const fs = require('fs').promises;
+const fsSync = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Configurable via MC_CLAUDE_HOME env var.
+// Auto-detect: check common locations if default ~/.claude doesn't exist.
+function detectClaudeHome() {
+    if (process.env.MC_CLAUDE_HOME) return process.env.MC_CLAUDE_HOME;
+    const candidates = [
+        path.join(os.homedir(), '.claude'),
+        '/home/xcloud/.claude',
+        '/root/.claude',
+    ];
+    for (const c of candidates) {
+        if (fsSync.existsSync(path.join(c, 'projects'))) return c;
+    }
+    return candidates[0]; // fall back to default even if missing
+}
+const CLAUDE_HOME = detectClaudeHome();
+const PROJECTS_DIR = path.join(CLAUDE_HOME, 'projects');
+
+// Approximate cost per 1M tokens (USD) — fallback if no model-specific pricing
+const MODEL_PRICING = {
+  'claude-opus-4':      { input: 15.00, output: 75.00 },
+  'claude-opus-4-5':    { input: 15.00, output: 75.00 },
+  'claude-sonnet-4':    { input: 3.00,  output: 15.00 },
+  'claude-sonnet-4-5':  { input: 3.00,  output: 15.00 },
+  'claude-sonnet-4-6':  { input: 3.00,  output: 15.00 },
+  'claude-haiku-4':     { input: 0.80,  output: 4.00  },
+  'claude-haiku-4-5':   { input: 0.80,  output: 4.00  },
+  'claude-3-5-sonnet':  { input: 3.00,  output: 15.00 },
+  'claude-3-5-haiku':   { input: 0.80,  output: 4.00  },
+  'claude-3-opus':      { input: 15.00, output: 75.00 },
+  default:              { input: 3.00,  output: 15.00 },
+};
+
+// Session is considered "active" if last message was within 30 minutes
+const ACTIVE_THRESHOLD_MS = 30 * 60 * 1000;
+
+// In-memory cache: sessionId → session data
+let sessionCache = new Map();
+let lastScan = null;
+let scanInterval = null;
+
+/**
+ * Convert a project directory name to a human-readable project path.
+ * Claude encodes paths as: -root--openclaw-workspace-foo → /root/.openclaw/workspace/foo
+ */
+function decodeProjectDir(dirName) {
+  // Replace leading dash + double dashes to reconstruct the path
+  return dirName
+    .replace(/^-/, '/')          // leading - → /
+    .replace(/--/g, '/')         // -- → /
+    .replace(/-([^-])/g, '/$1'); // remaining -x → /x  (handles single dashes in dir names poorly, best effort)
+}
+
+/**
+ * Parse a single JSONL session file and extract session metadata.
+ */
+async function parseSessionFile(filePath, projectDir) {
+  const sessionId = path.basename(filePath, '.jsonl');
+  let firstTimestamp = null;
+  let lastTimestamp = null;
+  let messageCount = 0;
+  let userMessages = 0;
+  let assistantMessages = 0;
+  let model = null;
+  let version = null;
+  let gitBranch = null;
+  let cwd = null;
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+  let totalCacheReadTokens = 0;
+  let totalCacheCreationTokens = 0;
+  let hasError = false;
+  let lastError = null;
+
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const lines = raw.trim().split('\n').filter(Boolean);
+
+    for (const line of lines) {
+      let entry;
+      try {
+        entry = JSON.parse(line);
+      } catch {
+        continue; // Skip malformed lines
+      }
+
+      if (!entry.timestamp) continue;
+
+      const ts = new Date(entry.timestamp).getTime();
+      if (!firstTimestamp || ts < firstTimestamp) firstTimestamp = ts;
+      if (!lastTimestamp || ts > lastTimestamp) lastTimestamp = ts;
+
+      // Extract metadata from user/assistant messages
+      if (entry.type === 'user') {
+        userMessages++;
+        messageCount++;
+        if (!version && entry.version) version = entry.version;
+        if (!gitBranch && entry.gitBranch) gitBranch = entry.gitBranch;
+        if (!cwd && entry.cwd) cwd = entry.cwd;
+      }
+
+      if (entry.type === 'assistant') {
+        assistantMessages++;
+        messageCount++;
+        if (!version && entry.version) version = entry.version;
+        if (!gitBranch && entry.gitBranch) gitBranch = entry.gitBranch;
+        if (!cwd && entry.cwd) cwd = entry.cwd;
+
+        // Extract token usage from assistant messages
+        if (entry.message && entry.message.usage) {
+          const u = entry.message.usage;
+          totalInputTokens += (u.input_tokens || 0);
+          totalOutputTokens += (u.output_tokens || 0);
+          totalCacheReadTokens += (u.cache_read_input_tokens || 0);
+          totalCacheCreationTokens += (u.cache_creation_input_tokens || 0);
+        }
+
+        // Extract model
+        if (!model && entry.message && entry.message.model) {
+          model = entry.message.model;
+        }
+
+        // Track errors
+        if (entry.error) {
+          hasError = true;
+          lastError = entry.error;
+        }
+        if (entry.isApiErrorMessage) {
+          hasError = true;
+        }
+      }
+
+      // Also check summary/usage entries some versions emit
+      if (entry.type === 'usage' || entry.type === 'summary') {
+        if (entry.usage) {
+          totalInputTokens += (entry.usage.input_tokens || 0);
+          totalOutputTokens += (entry.usage.output_tokens || 0);
+        }
+        if (entry.model && !model) model = entry.model;
+      }
+    }
+  } catch (err) {
+    // File read error — return minimal session
+    return {
+      sessionId,
+      projectDir,
+      project: decodeProjectDir(projectDir),
+      error: err.message,
+      messageCount: 0,
+      active: false,
+    };
+  }
+
+  // Cost estimate
+  const pricing = getModelPricing(model);
+  const inputCost = (totalInputTokens / 1_000_000) * pricing.input;
+  const outputCost = (totalOutputTokens / 1_000_000) * pricing.output;
+  const cacheReadCost = (totalCacheReadTokens / 1_000_000) * (pricing.input * 0.1); // cache read ~10% of input
+  const estimatedCost = inputCost + outputCost + cacheReadCost;
+
+  const now = Date.now();
+  const active = lastTimestamp ? (now - lastTimestamp) < ACTIVE_THRESHOLD_MS : false;
+
+  return {
+    sessionId,
+    projectDir,
+    project: cwd || decodeProjectDir(projectDir),
+    model: model || 'unknown',
+    version: version || 'unknown',
+    gitBranch: gitBranch || null,
+    messageCount,
+    userMessages,
+    assistantMessages,
+    tokens: {
+      input: totalInputTokens,
+      output: totalOutputTokens,
+      cacheRead: totalCacheReadTokens,
+      cacheCreation: totalCacheCreationTokens,
+      total: totalInputTokens + totalOutputTokens,
+    },
+    cost: {
+      estimated: Math.round(estimatedCost * 10000) / 10000, // 4 decimal places
+      currency: 'USD',
+    },
+    firstSeen: firstTimestamp ? new Date(firstTimestamp).toISOString() : null,
+    lastSeen: lastTimestamp ? new Date(lastTimestamp).toISOString() : null,
+    active,
+    hasError,
+    lastError: lastError || null,
+  };
+}
+
+function getModelPricing(model) {
+  if (!model) return MODEL_PRICING.default;
+  const key = Object.keys(MODEL_PRICING).find(k => model.includes(k));
+  return key ? MODEL_PRICING[key] : MODEL_PRICING.default;
+}
+
+/**
+ * Scan all projects and sessions under CLAUDE_HOME/projects/.
+ * Returns array of session objects.
+ */
+async function scanSessions() {
+  try {
+    await fs.access(PROJECTS_DIR);
+  } catch {
+    // No projects directory — Claude Code not installed or no sessions yet
+    return [];
+  }
+
+  const sessions = [];
+  let projectDirs;
+
+  try {
+    projectDirs = await fs.readdir(PROJECTS_DIR);
+  } catch {
+    return [];
+  }
+
+  for (const projectDir of projectDirs) {
+    const projectPath = path.join(PROJECTS_DIR, projectDir);
+    let stat;
+    try {
+      stat = await fs.stat(projectPath);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+
+    let files;
+    try {
+      files = await fs.readdir(projectPath);
+    } catch {
+      continue;
+    }
+
+    const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
+    for (const file of jsonlFiles) {
+      const filePath = path.join(projectPath, file);
+      const session = await parseSessionFile(filePath, projectDir);
+      sessions.push(session);
+    }
+  }
+
+  // Sort: active first, then by lastSeen desc
+  sessions.sort((a, b) => {
+    if (a.active && !b.active) return -1;
+    if (!a.active && b.active) return 1;
+    const aTs = a.lastSeen ? new Date(a.lastSeen).getTime() : 0;
+    const bTs = b.lastSeen ? new Date(b.lastSeen).getTime() : 0;
+    return bTs - aTs;
+  });
+
+  // Update cache
+  sessionCache = new Map(sessions.map(s => [s.sessionId, s]));
+  lastScan = new Date().toISOString();
+
+  return sessions;
+}
+
+/**
+ * Get sessions from cache (instant, no disk I/O).
+ */
+function getCachedSessions() {
+  return {
+    sessions: Array.from(sessionCache.values()),
+    lastScan,
+    claudeHome: CLAUDE_HOME,
+    projectsDir: PROJECTS_DIR,
+  };
+}
+
+/**
+ * Start background scanner — scans every 60 seconds.
+ */
+function startScanner() {
+  if (scanInterval) return; // Already running
+
+  // Initial scan
+  scanSessions().catch(err => console.error('[claude-sessions] Initial scan error:', err));
+
+  scanInterval = setInterval(() => {
+    scanSessions().catch(err => console.error('[claude-sessions] Scan error:', err));
+  }, 60_000);
+
+  console.log(`[claude-sessions] Scanner started — watching ${PROJECTS_DIR} every 60s`);
+}
+
+/**
+ * Stop background scanner.
+ */
+function stopScanner() {
+  if (scanInterval) {
+    clearInterval(scanInterval);
+    scanInterval = null;
+  }
+}
+
+module.exports = {
+  startScanner,
+  stopScanner,
+  scanSessions,
+  getCachedSessions,
+  CLAUDE_HOME,
+  PROJECTS_DIR,
+};

--- a/server/index.js
+++ b/server/index.js
@@ -19,6 +19,7 @@ const http = require('http');
 const ResourceManager = require('./resource-manager');
 const ReviewManager = require('./review-manager');
 const telegramBridge = require('./telegram-bridge');
+const claudeSessions = require('./claude-sessions');
 
 // Input sanitization helper
 function sanitizeInput(val) {
@@ -1832,6 +1833,69 @@ app.get('/api/metrics', async (req, res) => {
 });
 
 // ============================================
+// Claude Code Session Routes (v1.2.0)
+// ============================================
+
+/**
+ * GET /api/claude/sessions
+ * List all discovered Claude Code sessions.
+ * Query params:
+ *   ?active=1   — only return active sessions (last message < 30min ago)
+ *   ?project=   — filter by project path substring
+ *   ?scan=1     — force an immediate rescan before responding
+ */
+app.get('/api/claude/sessions', async (req, res) => {
+    try {
+        if (req.query.scan === '1') {
+            await claudeSessions.scanSessions();
+        }
+        const { sessions, lastScan, claudeHome, projectsDir } = claudeSessions.getCachedSessions();
+
+        let filtered = sessions;
+
+        if (req.query.active === '1') {
+            filtered = filtered.filter(s => s.active);
+        }
+
+        if (req.query.project) {
+            const q = req.query.project.toLowerCase();
+            filtered = filtered.filter(s => s.project && s.project.toLowerCase().includes(q));
+        }
+
+        res.json({
+            sessions: filtered,
+            total: filtered.length,
+            totalAll: sessions.length,
+            activeCount: sessions.filter(s => s.active).length,
+            lastScan,
+            claudeHome,
+            projectsDir,
+        });
+    } catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+});
+
+/**
+ * POST /api/claude/sessions
+ * Trigger a manual rescan of Claude Code sessions.
+ */
+app.post('/api/claude/sessions', async (req, res) => {
+    try {
+        const sessions = await claudeSessions.scanSessions();
+        res.json({
+            ok: true,
+            message: 'Scan complete',
+            total: sessions.length,
+            activeCount: sessions.filter(s => s.active).length,
+            lastScan: new Date().toISOString(),
+        });
+    } catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+});
+
+// ============================================
 // Serve dashboard static files (MUST be before catch-all route)
 app.use(express.static(DASHBOARD_DIR));
 
@@ -1874,6 +1938,9 @@ server.listen(PORT, () => {
             });
         }
     }
+
+    // Start Claude Code session scanner
+    claudeSessions.startScanner();
 
     const mdLine = process.env.MISSIONDECK_API_KEY
         ? `║   MissionDeck:  https://missiondeck.ai/workspace/${process.env.MISSIONDECK_SLUG || '???'}    ║`

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jarvis-mission-control-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Backend server for JARVIS Mission Control - handles data persistence, real-time updates, and OpenClaw agent integration",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Week 2, Task 1 — Claude Code Session Tracking

### What's new
Auto-discovers local Claude Code sessions by scanning `~/.claude/projects/` JSONL transcripts.

### Files changed
- **`server/claude-sessions.js`** (new) — scanner module
  - Auto-detects Claude home across: `/home/xcloud/.claude`, `~/.claude`, `/root/.claude`
  - Parses JSONL files: extracts tokens, model, cost estimates, git branch, active status
  - Background scanner runs every 60s via `startScanner()`
- **`server/index.js`** — wired in scanner + added routes
  - `GET /api/claude/sessions` — list sessions (filters: `?active=1`, `?project=`, `?scan=1`)
  - `POST /api/claude/sessions` — trigger manual rescan
- **`dashboard/js/claude-sessions.js`** (new) — frontend panel
- **`dashboard/index.html`** — Claude Sessions entry in sidebar + slide-out panel

### Tested
- `/api/claude/sessions` returns 1 session (chatrank project) ✅
- Auto-detects `/home/xcloud/.claude` ✅  
- Scanner starts with server ✅
- Session data: project path decoded, model extracted, error flagged ✅

### Version
`1.1.0` → `1.2.0`

cc @MorpheusMatrixZ_Bot — please test and approve 🎭