### PR TITLE
feat: v1.16.0 — Dashboard Widget Cards

### DIFF
--- a/dashboard/css/styles.css
+++ b/dashboard/css/styles.css
@@ -5435,3 +5435,145 @@ body::after {
 [data-theme="light"] .quota-progress-bar {
     background: var(--bg-tertiary);
 }
+
+/* ============================================
+   FEATURE WIDGET CARDS (v1.16.0)
+   Second metrics row — clickable stat cards
+   ============================================ */
+
+.metrics-cards {
+    display: flex;
+    gap: 12px;
+    padding: 10px 24px;
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-color);
+    flex-wrap: wrap;
+}
+
+.feature-card {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    background: rgba(0, 255, 65, 0.05);
+    border: 1px solid rgba(0, 255, 65, 0.2);
+    border-radius: 8px;
+    padding: 12px 16px;
+    min-width: 180px;
+    flex: 1;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.feature-card::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(0, 255, 65, 0.4), transparent);
+}
+
+.feature-card:hover {
+    border-color: rgba(0, 255, 65, 0.5);
+    box-shadow: 0 0 12px rgba(0, 255, 65, 0.15);
+    transform: translateY(-1px);
+}
+
+.fcard-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 4px;
+}
+
+.fcard-icon {
+    font-size: 14px;
+}
+
+.fcard-title {
+    font-size: 11px;
+    font-family: 'Orbitron', monospace;
+    letter-spacing: 0.08em;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    flex: 1;
+}
+
+.fcard-status-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #555;
+    flex-shrink: 0;
+}
+
+.fcard-status-dot.healthy {
+    background: #00ff41;
+    box-shadow: 0 0 6px rgba(0, 255, 65, 0.6);
+}
+
+.fcard-status-dot.warning {
+    background: #ffcc00;
+    box-shadow: 0 0 6px rgba(255, 204, 0, 0.6);
+}
+
+.fcard-status-dot.error {
+    background: #ff4444;
+    box-shadow: 0 0 6px rgba(255, 68, 68, 0.6);
+}
+
+.fcard-metric {
+    font-family: 'Orbitron', monospace;
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--neon-green);
+    line-height: 1;
+    margin: 2px 0;
+}
+
+.fcard-secondary {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-family: 'Share Tech Mono', monospace;
+}
+
+.fcard-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 6px;
+    padding-top: 6px;
+    border-top: 1px solid rgba(0, 255, 65, 0.1);
+}
+
+.fcard-time {
+    font-size: 10px;
+    color: var(--text-muted);
+    font-family: 'Share Tech Mono', monospace;
+}
+
+.fcard-arrow {
+    font-size: 12px;
+    color: rgba(0, 255, 65, 0.4);
+    transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.feature-card:hover .fcard-arrow {
+    color: var(--neon-green);
+    transform: translateX(3px);
+}
+
+.fcard-metric.error {
+    color: #ff4444;
+}
+
+.fcard-metric.warning {
+    color: #ffcc00;
+}
+
+@media (max-width: 768px) {
+    .metrics-cards {
+        display: none;
+    }
+}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -38,7 +38,7 @@
                 <span class="logo-icon">J</span>
                 JARVIS Mission Control
             </h1>
-            <span class="version">v1.15.0</span>
+            <span class="version">v1.16.0</span>
         </div>
         <div class="header-right">
             <div class="metrics">
@@ -58,23 +58,7 @@
                     <span class="metric-value" id="active-agents">0</span>
                     <span class="metric-label">Agents</span>
                 </div>
-                <!-- Aggregate widgets v1.15.0 -->
-                <div class="metric metric-widget" id="widget-claude" onclick="openClaudeSessions()" title="Claude Code Sessions" style="cursor:pointer;">
-                    <span class="metric-value" id="widget-claude-value">—</span>
-                    <span class="metric-label">🖥 Claude</span>
-                </div>
-                <div class="metric metric-widget" id="widget-cli" title="CLI Connections" style="cursor:pointer;" onclick="openCliConnectionsPanel && openCliConnectionsPanel()">
-                    <span class="metric-value" id="widget-cli-value">—</span>
-                    <span class="metric-label">⚡ CLI</span>
-                </div>
-                <div class="metric metric-widget" id="widget-github" title="GitHub Sync" style="cursor:pointer;">
-                    <span class="metric-value" id="widget-github-value">—</span>
-                    <span class="metric-label">🐙 GitHub</span>
-                </div>
-                <div class="metric metric-widget" id="widget-webhooks" title="Webhook Health" style="cursor:pointer;" onclick="loadWebhooksList()">
-                    <span class="metric-value" id="widget-webhooks-value">—</span>
-                    <span class="metric-label">🔔 Hooks</span>
-                </div>
+                <!-- Widget chips removed in v1.16.0 — replaced by feature-metrics cards below -->
             </div>
             <button class="btn btn-secondary" id="refresh-btn" onclick="forceRefreshBoard()" title="Reload all tasks from server">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -92,6 +76,62 @@
             </button>
         </div>
     </header>
+
+    <!-- Feature Widget Cards (v1.16.0) -->
+    <div class="metrics-cards" id="feature-metrics">
+        <div class="feature-card" id="fcard-claude" onclick="openClaudeSessions()" title="Open Claude Sessions">
+            <div class="fcard-header">
+                <span class="fcard-icon">🖥</span>
+                <span class="fcard-title">Claude Sessions</span>
+                <span class="fcard-status-dot" id="fcard-claude-dot"></span>
+            </div>
+            <div class="fcard-metric" id="fcard-claude-main">—</div>
+            <div class="fcard-secondary" id="fcard-claude-secondary">— total</div>
+            <div class="fcard-footer">
+                <span class="fcard-time" id="fcard-claude-time">Last scan: —</span>
+                <span class="fcard-arrow">→</span>
+            </div>
+        </div>
+        <div class="feature-card" id="fcard-cli" onclick="openCliConnectionsPanel ? openCliConnectionsPanel() : openCliConnections()" title="Open CLI Connections">
+            <div class="fcard-header">
+                <span class="fcard-icon">⚡</span>
+                <span class="fcard-title">CLI Connections</span>
+                <span class="fcard-status-dot" id="fcard-cli-dot"></span>
+            </div>
+            <div class="fcard-metric" id="fcard-cli-main">—</div>
+            <div class="fcard-secondary" id="fcard-cli-secondary">— total registered</div>
+            <div class="fcard-footer">
+                <span class="fcard-time" id="fcard-cli-time">Last scan: —</span>
+                <span class="fcard-arrow">→</span>
+            </div>
+        </div>
+        <div class="feature-card" id="fcard-github" onclick="openGithubPanel()" title="Open GitHub Sync">
+            <div class="fcard-header">
+                <span class="fcard-icon">🐙</span>
+                <span class="fcard-title">GitHub Sync</span>
+                <span class="fcard-status-dot" id="fcard-github-dot"></span>
+            </div>
+            <div class="fcard-metric" id="fcard-github-main">—</div>
+            <div class="fcard-secondary" id="fcard-github-secondary">synced issues</div>
+            <div class="fcard-footer">
+                <span class="fcard-time" id="fcard-github-time">Last sync: —</span>
+                <span class="fcard-arrow">→</span>
+            </div>
+        </div>
+        <div class="feature-card" id="fcard-webhooks" onclick="loadWebhooksList()" title="Open Webhook Health">
+            <div class="fcard-header">
+                <span class="fcard-icon">🔔</span>
+                <span class="fcard-title">Webhook Health</span>
+                <span class="fcard-status-dot" id="fcard-webhooks-dot"></span>
+            </div>
+            <div class="fcard-metric" id="fcard-webhooks-main">—</div>
+            <div class="fcard-secondary" id="fcard-webhooks-secondary">— open circuits</div>
+            <div class="fcard-footer">
+                <span class="fcard-time" id="fcard-webhooks-time">Last scan: —</span>
+                <span class="fcard-arrow">→</span>
+            </div>
+        </div>
+    </div>
 
     <main class="main-content">
         <!-- Sidebar (LEFT) - Command Panel -->

--- a/dashboard/js/dashboard-widgets.js
+++ b/dashboard/js/dashboard-widgets.js
@@ -1,112 +1,148 @@
 /**
- * Dashboard Aggregate Widgets — JARVIS Mission Control v1.15.0
+ * Dashboard Aggregate Widgets — JARVIS Mission Control v1.16.0
  *
- * Polls APIs every 60s and updates the header metric chips:
- *   🖥 Claude   — active Claude Code sessions
- *   ⚡ CLI       — connected CLI tools
- *   🐙 GitHub   — synced issues count
- *   🔔 Hooks    — webhook health (open circuits)
+ * Polls APIs every 60s and updates the feature card row:
+ *   🖥 Claude Sessions
+ *   ⚡ CLI Connections
+ *   🐙 GitHub Sync
+ *   🔔 Webhook Health
  */
 
 const WIDGET_POLL_MS = 60_000;
 
-// ── Update helpers ─────────────────────────────────────────────────────────
+// ── Time helper ────────────────────────────────────────────────────────────
 
-function _setWidget(id, value, title, color) {
-    const el = document.getElementById(id);
-    if (!el) return;
-    el.textContent = value;
-    if (color) el.style.color = color;
-    if (title) el.parentElement.title = title;
+function _timeAgo(ts) {
+    if (!ts) return '—';
+    const diff = Math.floor((Date.now() - new Date(ts).getTime()) / 1000);
+    if (diff < 60) return `${diff}s ago`;
+    if (diff < 3600) return `${Math.floor(diff / 60)} min ago`;
+    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+    return `${Math.floor(diff / 86400)}d ago`;
+}
+
+// ── Feature card update helpers ────────────────────────────────────────────
+
+function _setFCard(id, { main, mainClass, secondary, dot, time }) {
+    const mainEl = document.getElementById(`fcard-${id}-main`);
+    const secEl  = document.getElementById(`fcard-${id}-secondary`);
+    const dotEl  = document.getElementById(`fcard-${id}-dot`);
+    const timeEl = document.getElementById(`fcard-${id}-time`);
+
+    if (mainEl) {
+        mainEl.textContent = main !== undefined ? main : '—';
+        mainEl.className = 'fcard-metric' + (mainClass ? ` ${mainClass}` : '');
+    }
+    if (secEl  && secondary !== undefined) secEl.textContent = secondary;
+    if (dotEl  && dot) {
+        dotEl.className = `fcard-status-dot ${dot}`;
+    }
+    if (timeEl && time !== undefined) timeEl.textContent = time;
 }
 
 // ── Claude Code Sessions ───────────────────────────────────────────────────
 
+let _claudeLastScan = null;
+
 async function refreshClaudeWidget() {
     try {
         const res = await fetch('/api/claude/sessions');
-        if (!res.ok) return;
+        if (!res.ok) throw new Error('no data');
         const data = await res.json();
+        _claudeLastScan = new Date().toISOString();
         const active = data.activeCount || 0;
         const total  = data.total || 0;
-        _setWidget(
-            'widget-claude-value',
-            active > 0 ? `${active}/${total}` : total,
-            `Claude Code Sessions: ${active} active, ${total} total`,
-            active > 0 ? '#22c55e' : null
-        );
-    } catch { _setWidget('widget-claude-value', '?'); }
+        _setFCard('claude', {
+            main: active,
+            mainClass: active > 0 ? '' : '',
+            secondary: `${total} total`,
+            dot: active > 0 ? 'healthy' : 'warning',
+            time: `Last scan: ${_timeAgo(_claudeLastScan)}`,
+        });
+    } catch {
+        _setFCard('claude', { main: '?', secondary: 'unavailable', dot: 'error', time: 'Last scan: failed' });
+    }
 }
 
 // ── CLI Connections ────────────────────────────────────────────────────────
 
+let _cliLastScan = null;
+
 async function refreshCliWidget() {
     try {
         const res = await fetch('/api/connect');
-        if (!res.ok) return;
+        if (!res.ok) throw new Error('no data');
         const data = await res.json();
-        // data may be array or { connections: [] }
+        _cliLastScan = new Date().toISOString();
         const list   = Array.isArray(data) ? data : (data.connections || []);
         const active = list.filter(c => c.status === 'active' || c.active).length;
         const total  = list.length;
-        _setWidget(
-            'widget-cli-value',
-            active > 0 ? `${active}/${total}` : total,
-            `CLI Connections: ${active} active, ${total} total`,
-            active > 0 ? '#60a5fa' : null
-        );
-    } catch { _setWidget('widget-cli-value', '?'); }
+        _setFCard('cli', {
+            main: active,
+            secondary: `${total} total registered`,
+            dot: active > 0 ? 'healthy' : (total > 0 ? 'warning' : 'error'),
+            time: `Last scan: ${_timeAgo(_cliLastScan)}`,
+        });
+    } catch {
+        _setFCard('cli', { main: '?', secondary: 'unavailable', dot: 'error', time: 'Last scan: failed' });
+    }
 }
 
 // ── GitHub Sync ────────────────────────────────────────────────────────────
 
+let _githubLastScan = null;
+
 async function refreshGithubWidget() {
     try {
-        // GitHub synced issues appear as tasks with source:github or labels containing 'github'
-        // Try the tasks endpoint and filter
         const res = await fetch('/api/tasks');
-        if (!res.ok) return;
+        if (!res.ok) throw new Error('no data');
         const tasks = await res.json();
+        _githubLastScan = new Date().toISOString();
         const githubTasks = tasks.filter(t =>
             t.source === 'github' ||
             (Array.isArray(t.labels) && t.labels.some(l => String(l).toLowerCase().includes('github')))
         );
-        _setWidget(
-            'widget-github-value',
-            githubTasks.length,
-            `GitHub synced issues: ${githubTasks.length}`,
-            githubTasks.length > 0 ? '#a78bfa' : null
-        );
-    } catch { _setWidget('widget-github-value', '?'); }
+        const count = githubTasks.length;
+        _setFCard('github', {
+            main: count,
+            secondary: 'synced issues',
+            dot: count > 0 ? 'healthy' : 'warning',
+            time: `Last sync: ${_timeAgo(_githubLastScan)}`,
+        });
+    } catch {
+        _setFCard('github', { main: '?', secondary: 'unavailable', dot: 'error', time: 'Last sync: failed' });
+    }
 }
 
 // ── Webhook Health ─────────────────────────────────────────────────────────
 
+let _webhooksLastScan = null;
+
 async function refreshWebhooksWidget() {
     try {
         const res = await fetch('/api/webhooks');
-        if (!res.ok) return;
+        if (!res.ok) throw new Error('no data');
         const webhooks = await res.json();
-        const total   = webhooks.length;
-        const open    = webhooks.filter(w => w.circuitState === 'open').length;
+        _webhooksLastScan = new Date().toISOString();
+        const total    = webhooks.length;
+        const open     = webhooks.filter(w => w.circuitState === 'open').length;
         const halfOpen = webhooks.filter(w => w.circuitState === 'half-open').length;
 
-        let value = total;
-        let color = null;
-        let tip   = `Webhooks: ${total} registered`;
+        let dot = 'healthy';
+        let mainClass = '';
+        if (open > 0) { dot = 'error'; mainClass = 'error'; }
+        else if (halfOpen > 0) { dot = 'warning'; mainClass = 'warning'; }
 
-        if (open > 0) {
-            value = `${open}🔴`;
-            color = '#e53e3e';
-            tip   = `Webhooks: ${open} circuit(s) OPEN — click to view`;
-        } else if (halfOpen > 0) {
-            value = `${halfOpen}🟡`;
-            color = '#d69e2e';
-            tip   = `Webhooks: ${halfOpen} circuit(s) half-open`;
-        }
-
-        _setWidget('widget-webhooks-value', value, tip, color);
-    } catch { _setWidget('widget-webhooks-value', '?'); }
+        _setFCard('webhooks', {
+            main: total,
+            mainClass,
+            secondary: open > 0 ? `${open} open circuits` : (halfOpen > 0 ? `${halfOpen} half-open` : '0 open circuits'),
+            dot,
+            time: `Last scan: ${_timeAgo(_webhooksLastScan)}`,
+        });
+    } catch {
+        _setFCard('webhooks', { main: '?', secondary: 'unavailable', dot: 'error', time: 'Last scan: failed' });
+    }
 }
 
 // ── Poll all ───────────────────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jarvis-mission-control",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "JARVIS Mission Control — agent task management system with CLI",
   "bin": {
     "jarvis": "./scripts/jarvis.js"


### PR DESCRIPTION
## Dashboard Widget Cards (v1.16.0)

Replaces the 4 tiny widget chips in the header with proper clickable stat cards below the metrics row.

### Changes
- Added `.metrics-cards` row with 4 feature cards (Claude, CLI, GitHub, Webhooks)
- Each card: Matrix green border, hover glow, status dot, large metric, secondary info, last scan time
- Click opens relevant panel (`openClaudeSessions()`, `openCliConnectionsPanel()`, etc.)
- Removed old widget chips from header `.metrics` row
- Updated `dashboard-widgets.js` to populate new cards
- Added CSS for feature cards in `styles.css`
- Bumped to v1.16.0