### PR TITLE
fix: default dark mode + suppress Getting Started modal (v2.0.1)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -38,7 +38,7 @@
                 <span class="logo-icon">J</span>
                 JARVIS Mission Control
             </h1>
-            <span class="version">v2.0.0</span>
+            <span class="version">v2.0.1</span>
         </div>
         <div class="header-right">
             <div class="metrics">

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -81,9 +81,16 @@ async function init() {
     // Setup real-time message listeners
     setupMessageListeners();
 
-    // Show instructions on first visit
+    // Show instructions only on first visit AND only if server is NOT reachable yet.
+    // If we're already connected (server running), never show it.
+    // The panel is auto-hidden once dismissed — stored in localStorage permanently.
     if (!localStorage.getItem('mc-instructions-seen')) {
-        showInstructions();
+        // Delay check — if we connect within 2s, don't show it at all
+        setTimeout(() => {
+            if (!localStorage.getItem('mc-instructions-seen') && !api.isConnected()) {
+                showInstructions();
+            }
+        }, 2000);
     }
 
     console.log('Dashboard initialized');
@@ -216,10 +223,9 @@ function initTheme() {
     if (savedTheme) {
         currentTheme = savedTheme;
     } else {
-        // Check system preference
-        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
-            currentTheme = 'light';
-        }
+        // Always default to dark — JARVIS MC is a dark-first app.
+        // Do NOT follow system light preference unless user explicitly chose it.
+        currentTheme = 'dark';
     }
 
     if (savedColorTheme) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jarvis-mission-control",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "JARVIS Mission Control — agent task management system with CLI",
   "bin": {
     "jarvis": "./scripts/jarvis.js"

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jarvis-mission-control-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Backend server for JARVIS Mission Control - handles data persistence, real-time updates, and OpenClaw agent integration",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Bug Fixes — v2.0.1

Fixes two issues visible in the v2.0.0 screenshot:

### 1. Light mode default (Critical)
**Root cause:** `initTheme()` was checking `prefers-color-scheme: light` system setting and overriding the dark default when no localStorage value was saved. On a fresh visit from a system set to light mode, the dashboard rendered in white.

**Fix:** Removed the system preference check. JARVIS MC is dark-first. Default is always `dark` unless the user explicitly selects light via the settings panel (which saves to localStorage).

### 2. Getting Started modal blocking the board
**Root cause:** `showInstructions()` was called on every fresh session if `mc-instructions-seen` wasn't in localStorage.

**Fix:** 
- Only show after 2s delay
- Check `api.isConnected()` — if server is already running (which it always is), never show the panel
- Clicking "Got it!" already sets `mc-instructions-seen` permanently

### Tested
- Dashboard loads in dark/Matrix theme by default ✅
- Getting Started panel does not appear when server is running ✅
- Light mode still works via Settings toggle ✅
- PM2 restart clean ✅

### Version
`2.0.0` → `2.0.1`

@OracleM_Bot — please review and merge 🌐