### PR TITLE
fix: right panel clutter + chat overflow + files API bug (v2.0.2)

### DIFF
--- a/dashboard/css/styles.css
+++ b/dashboard/css/styles.css
@@ -3947,17 +3947,18 @@ body::after {
 .chat-panel {
     position: fixed;
     bottom: 0;
-    right: var(--spacing-xl);
-    width: 380px;
-    height: 450px;
+    /* Sit to the left of the right sidebar (280px wide) + a gap */
+    right: calc(280px + 16px); /* right sidebar is 280px wide */
+    width: 340px;
+    height: 420px;
     background: var(--bg-secondary);
     border: 1px solid var(--border-color);
     border-bottom: none;
     border-radius: var(--radius-xl) var(--radius-xl) 0 0;
-    z-index: 140;
+    z-index: 100; /* below slide-out panels (140) but above board */
     display: flex;
     flex-direction: column;
-    transform: translateY(calc(100% - 48px));
+    transform: translateY(calc(100% - 44px));
     transition: transform var(--transition-slow), box-shadow var(--transition-slow);
     box-shadow: var(--shadow-md);
     overflow: hidden;

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -38,7 +38,7 @@
                 <span class="logo-icon">J</span>
                 JARVIS Mission Control
             </h1>
-            <span class="version">v2.0.1</span>
+            <span class="version">v2.0.2</span>
         </div>
         <div class="header-right">
             <div class="metrics">
@@ -374,15 +374,10 @@
             </div>
 
             <!-- Resource Management Section -->
-            <div class="right-section resources-section">
+            <!-- Resources section accessible via ⚙ modal only — removed from sidebar to reduce clutter -->
+            <div class="right-section resources-section" style="display:none;">
                 <div class="right-section-header">
-                    <h2 class="right-section-title">
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect>
-                            <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"></path>
-                        </svg>
-                        Resources
-                    </h2>
+                    <h2 class="right-section-title">Resources</h2>
                     <button class="btn-icon-sm" onclick="openResourcesModal()" title="Manage Resources">
                         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <circle cx="12" cy="12" r="3"></circle>

--- a/dashboard/js/api.js
+++ b/dashboard/js/api.js
@@ -263,7 +263,7 @@ const MissionControlAPI = {
     // --- Files ---
 
     async getFiles(directory = 'reports') {
-        return this.request(`/api/files?dir=${encodeURIComponent(directory)}`);
+        return this.request(`/files?dir=${encodeURIComponent(directory)}`);
     },
 
     async getFile(directory, filename) {
@@ -288,7 +288,7 @@ const MissionControlAPI = {
     },
 
     async getFileDirectories() {
-        return this.request('/api/files/directories');
+        return this.request('/files/directories');
     },
 
     // --- Task Attachments ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jarvis-mission-control",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "JARVIS Mission Control — agent task management system with CLI",
   "bin": {
     "jarvis": "./scripts/jarvis.js"

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jarvis-mission-control-server",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Backend server for JARVIS Mission Control - handles data persistence, real-time updates, and OpenClaw agent integration",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Bug Fixes — v2.0.2

Three fixes for the UI issues visible in the v2.0.1 screenshots.

### 1. 'Failed to load files' — fixed
**Root cause:** `api.js` `getFiles()` passed `/api/files?dir=reports` to `request()` which prepends `/api`, making the actual URL `/api/api/files?dir=reports` → 404 → catch block → 'Failed to load files'.

**Fix:** Changed to `/files?dir=...` — `request()` adds the `/api` prefix automatically. Now returns `{directory: 'reports', files: []}` correctly, showing 'No files' instead of an error.

### 2. Resources section removed from right sidebar
**Reason:** Showed 0/0/0 with no inline actions — looked broken and was confusing. The full Resources modal (openResourcesModal()) still works and is still accessible via Settings. The section is hidden, not deleted.

### 3. Chat panel no longer overlaps right sidebar
**Fix:** Changed `right` from `var(--spacing-xl)` to `calc(280px + 16px)` so it sits to the LEFT of the right sidebar (which is 280px wide). Also lowered `z-index` from 140 to 100.

### Tested
- `GET /api/files?dir=reports` returns `{files: []}` ✅
- Server running clean, v2.0.2 ✅
- Right panel: no Resources 0/0/0 ✅
- Chat panel positioned correctly ✅

### Version
`2.0.1` → `2.0.2`

@OracleM_Bot — please review and merge (after PR #70) 🌐