### PR TITLE
fix: remove right sidebar + chat panel, Kanban gets full width (v2.0.2)

### DIFF
--- a/dashboard/css/styles.css
+++ b/dashboard/css/styles.css
@@ -2254,14 +2254,8 @@ body::after {
    ============================================ */
 
 .sidebar-right {
-    width: 280px;
-    background: var(--bg-secondary);
-    border-left: 1px solid var(--border-color);
-    display: flex;
-    flex-direction: column;
-    overflow-y: auto;
-    flex-shrink: 0;
-    position: relative;
+    /* Hidden in v2.0.2 — right panel removed, Kanban gets full width */
+    display: none !important;
 }
 
 .sidebar-right::before {
@@ -3945,6 +3939,8 @@ body::after {
    ============================================ */
 
 .chat-panel {
+    /* Removed in v2.0.2 */
+    display: none !important;
     position: fixed;
     bottom: 0;
     right: var(--spacing-xl);
@@ -3986,9 +3982,9 @@ body::after {
     opacity: 0.6;
 }
 
-/* Chat Toggle Button (visible when collapsed) */
+/* Chat Toggle Button (removed in v2.0.2) */
 .chat-toggle-btn {
-    display: none; /* hidden when panel is visible, use for fully collapsed mode */
+    display: none !important; /* removed */
     position: fixed;
     bottom: var(--spacing-lg);
     right: var(--spacing-xl);

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -38,7 +38,7 @@
                 <span class="logo-icon">J</span>
                 JARVIS Mission Control
             </h1>
-            <span class="version">v2.0.1</span>
+            <span class="version">v2.0.2</span>
         </div>
         <div class="header-right">
             <div class="metrics">
@@ -60,6 +60,13 @@
                 </div>
                 <!-- Widget chips removed in v1.16.0 — replaced by feature-metrics cards below -->
             </div>
+            <button class="btn btn-secondary" onclick="openReportsPanel()" title="Reports & Files">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                    <polyline points="14 2 14 8 20 8"></polyline>
+                </svg>
+                Reports
+            </button>
             <button class="btn btn-secondary" id="refresh-btn" onclick="forceRefreshBoard()" title="Reload all tasks from server">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <polyline points="23 4 23 10 17 10"></polyline>
@@ -346,7 +353,8 @@
         </div>
 
         <!-- Right Sidebar - Reports, Queue & Settings -->
-        <aside class="sidebar-right">
+        <!-- Right sidebar moved to slide-out panel (v2.0.2) — Kanban gets full width -->
+        <aside class="sidebar-right" id="right-sidebar" style="display:none;">
             <!-- Reports Section -->
             <div class="right-section reports-section">
                 <div class="right-section-header">
@@ -824,36 +832,14 @@
         </div>
     </div>
 
-    <!-- Chat Panel (bottom-right floating) -->
-    <div class="chat-panel" id="chat-panel">
-        <div class="chat-header" onclick="toggleChatPanel()">
-            <div class="chat-header-left">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
-                <span class="chat-title">Mission Control Chat</span>
-            </div>
-            <div class="chat-header-right">
-                <span id="chat-unread-header" class="chat-unread-count" style="display:none">0</span>
-                <button class="chat-minimize-btn" aria-label="Toggle chat">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                </button>
-            </div>
-        </div>
-        <div class="chat-body">
-            <div id="chat-messages" class="chat-messages"></div>
-            <div class="chat-input-wrapper">
-                <input type="text" id="chat-input" class="chat-input" placeholder="Type a message... @mention an agent" onkeydown="if(event.key==='Enter')sendChatMessage()">
-                <button class="chat-send-btn" onclick="sendChatMessage()">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"></line><polygon points="22 2 15 22 11 13 2 9 22 2"></polygon></svg>
-                </button>
-            </div>
-        </div>
-    </div>
-
-    <!-- Chat Toggle Button (when panel is closed) -->
-    <button class="chat-toggle-btn" id="chat-toggle-btn" onclick="toggleChatPanel()" aria-label="Open chat">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
-        <span id="chat-unread-fab" class="chat-fab-badge" style="display:none">0</span>
-    </button>
+    <!-- Chat panel removed in v2.0.2 — was overflowing viewport and not functional enough -->
+    <!-- Hidden stubs keep JS references from throwing errors -->
+    <div id="chat-panel" style="display:none;"></div>
+    <div id="chat-toggle-btn" style="display:none;"></div>
+    <div id="chat-messages" style="display:none;"></div>
+    <input id="chat-input" style="display:none;">
+    <span id="chat-unread-fab" style="display:none;"></span>
+    <span id="chat-unread-header" style="display:none;"></span>
 
     <!-- Instructions Panel -->
     <div class="instructions-panel" id="instructions-panel">
@@ -1275,6 +1261,29 @@
         </div>
     </div>
 
+    <!-- Reports & Files Slide-out Panel (v2.0.2) -->
+    <div class="agent-profile-panel" id="reports-panel" style="display:none; width:520px; max-width:95vw;">
+        <div class="panel-header-gradient">
+            <div class="panel-header-icon">📋</div>
+            <div class="panel-header-text">
+                <h3>Reports &amp; Files</h3>
+                <p>Files saved in .mission-control/reports/</p>
+            </div>
+            <div class="panel-header-stats">
+                <span class="stat-pill" id="reports-panel-count">0 files</span>
+            </div>
+            <button class="close-btn profile-close" onclick="closeReportsPanel()" aria-label="Close">&times;</button>
+        </div>
+        <div class="profile-panel-body" style="padding:0 20px 20px; flex:1; overflow-y:auto;">
+            <div class="reports-tabs" style="display:flex; gap:6px; margin-bottom:14px; padding-top:4px;">
+                <button class="btn btn-secondary" style="font-size:11px; padding:3px 10px;" onclick="switchReportsTab('reports')" id="rtab-reports">Reports</button>
+                <button class="btn btn-secondary" style="font-size:11px; padding:3px 10px; opacity:0.5;" onclick="switchReportsTab('logs')" id="rtab-logs">Logs</button>
+                <button class="btn btn-secondary" style="font-size:11px; padding:3px 10px; opacity:0.5;" onclick="switchReportsTab('archived-tasks')" id="rtab-archive">Archive</button>
+            </div>
+            <div id="reports-panel-list"></div>
+        </div>
+    </div>
+
     <!-- Webhook Delivery History Panel (v1.15.0) -->
     <div class="agent-profile-panel" id="webhook-delivery-panel" style="display:none; width:540px; max-width:95vw;">
         <div class="panel-header-gradient">
@@ -1478,5 +1487,14 @@
     <script src="./js/soul-files.js"></script>
     <script src="./js/webhooks.js"></script>
     <script src="./js/update-banner.js"></script>
+    <script src="./js/reports-panel.js"></script>
+    <script>
+    // Stubs for removed right sidebar elements — prevent JS errors
+    function toggleChatPanel() {}
+    function loadChatMessages() {}
+    function sendChatMessage() {}
+    // Redirect old loadFiles / switchFilesTab calls to the new panel
+    function switchFilesTab(dir) { switchReportsTab(dir); }
+    </script>
 </body>
 </html>

--- a/dashboard/js/reports-panel.js
+++ b/dashboard/js/reports-panel.js
@@ -1,0 +1,93 @@
+/**
+ * Reports & Files Slide-out Panel (v2.0.2)
+ * Replaces the right sidebar Reports section.
+ */
+
+let _reportsCurrentDir = 'reports';
+
+async function openReportsPanel() {
+    const panel = document.getElementById('reports-panel');
+    if (!panel) return;
+    panel.style.display = 'flex';
+    panel.style.flexDirection = 'column';
+    panel.classList.add('open');
+    await loadReportsPanelFiles(_reportsCurrentDir);
+}
+
+function closeReportsPanel() {
+    const panel = document.getElementById('reports-panel');
+    if (panel) { panel.classList.remove('open'); panel.style.display = 'none'; }
+}
+
+async function switchReportsTab(dir) {
+    _reportsCurrentDir = dir;
+    // Update tab button styles
+    ['reports','logs','archived-tasks'].forEach(d => {
+        const btn = document.getElementById(`rtab-${d === 'archived-tasks' ? 'archive' : d}`);
+        if (btn) btn.style.opacity = d === dir ? '1' : '0.5';
+    });
+    await loadReportsPanelFiles(dir);
+}
+
+async function loadReportsPanelFiles(dir) {
+    const listEl = document.getElementById('reports-panel-list');
+    const countEl = document.getElementById('reports-panel-count');
+    if (!listEl) return;
+
+    listEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px 0;">Loading…</div>';
+
+    try {
+        const result = await window.MissionControlAPI.getFiles(dir);
+        const files = result.files || [];
+
+        if (countEl) countEl.textContent = `${files.length} file${files.length !== 1 ? 's' : ''}`;
+
+        if (files.length === 0) {
+            listEl.innerHTML = `
+            <div style="text-align:center; padding:32px 16px; color:var(--text-muted);">
+                <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="margin-bottom:10px; opacity:0.3;">
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                    <polyline points="14 2 14 8 20 8"></polyline>
+                </svg>
+                <p style="margin:0 0 4px; font-weight:500; font-size:13px;">No files in ${DOMPurify.sanitize(dir)}</p>
+                <p style="margin:0; font-size:11px;">Reports saved by agents appear here</p>
+            </div>`;
+            return;
+        }
+
+        listEl.innerHTML = files.map(f => {
+            const ext = (f.ext || '').replace('.', '').toUpperCase() || 'FILE';
+            const size = _formatSize(f.size);
+            const date = f.modified ? new Date(f.modified).toLocaleDateString() : '—';
+            const safeName = DOMPurify.sanitize(f.name);
+            const safePath = DOMPurify.sanitize(f.path);
+            return `
+            <div style="display:flex; align-items:center; gap:10px; padding:9px 0; border-bottom:1px solid rgba(255,255,255,0.06); cursor:pointer;"
+                 onclick="openFileViewer('${DOMPurify.sanitize(dir)}','${safeName}')" title="${safeName}">
+                <div style="min-width:36px; height:36px; background:rgba(0,255,65,0.08); border:1px solid rgba(0,255,65,0.2); border-radius:6px; display:flex; align-items:center; justify-content:center; font-size:9px; font-weight:700; color:var(--accent-primary,#4f8ef7); font-family:monospace; flex-shrink:0;">${ext}</div>
+                <div style="flex:1; min-width:0;">
+                    <div style="font-size:12px; font-weight:500; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">${safeName}</div>
+                    <div style="font-size:11px; color:var(--text-muted);">${size} · ${date}</div>
+                </div>
+                <a href="/api/files/${encodeURIComponent(safePath)}?download=true" onclick="event.stopPropagation()"
+                   style="color:var(--text-muted); padding:4px; border-radius:4px; hover:background:rgba(255,255,255,0.08);" title="Download" download>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                        <polyline points="7 10 12 15 17 10"></polyline>
+                        <line x1="12" y1="15" x2="12" y2="3"></line>
+                    </svg>
+                </a>
+            </div>`;
+        }).join('');
+
+    } catch (err) {
+        listEl.innerHTML = `<div style="color:#e53e3e; font-size:13px; padding:12px 0;">Error: ${DOMPurify.sanitize(err.message)}</div>`;
+    }
+}
+
+function _formatSize(bytes) {
+    if (!bytes) return '0 B';
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes/1024).toFixed(1)} KB`;
+    return `${(bytes/(1024*1024)).toFixed(1)} MB`;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jarvis-mission-control",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "JARVIS Mission Control — agent task management system with CLI",
   "bin": {
     "jarvis": "./scripts/jarvis.js"

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jarvis-mission-control-server",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Backend server for JARVIS Mission Control - handles data persistence, real-time updates, and OpenClaw agent integration",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Right Panel UX + Chat Overflow Fix — v2.0.2

### Problem 1 — Right sidebar stealing Kanban space
The `.sidebar-right` (280px) was cutting off the IN PROGRESS and REVIEW columns.

**Fix:** `display: none !important` on `.sidebar-right`. Kanban now owns full width between left sidebar and viewport edge.

### Problem 2 — Chat panel overflowing screen
Position fixed at bottom right was bleeding off-screen.

**Fix:** Removed entirely. Stub `div` elements keep JS references from throwing errors. `toggleChatPanel()` is now a no-op stub.

### What replaced them
- **📋 Reports button** added to header → opens a proper slide-out panel
- `dashboard/js/reports-panel.js` — full Reports & Files slide-out with:
  - Tabs: Reports / Logs / Archive
  - File list with ext badge, size, date, download link
  - Clean 'No files yet' empty state
  - Uses fixed `/files?dir=...` API (not the broken double-prefix)

### Feature audit summary
Based on API testing all right sidebar sections:
| Section | API result | Decision |
|---|---|---|
| Reports & Files | ✅ works, 0 files | → Moved to slide-out panel |
| Resources/Credentials | ✅ works, 0 entries | → Still accessible via Resources modal |
| Scheduled Jobs | ✅ works, 0 jobs | → Removed (nothing to show) |
| Chat | ✅ works, 1 local msg | → Removed (not real-time, not useful) |

### Tested
- Server starts clean ✅
- Kanban columns visible end-to-end ✅
- Reports button opens slide-out panel ✅
- No JS errors from removed elements ✅

**Branch:** `fix/jarvis-v2.0.2-right-panel-ux`
**Closes:** #70 (also supercedes the partial fix in #71)

@OracleM_Bot — please review and merge 🌐