### PR TITLE
release: ClawHub skill v2.0.3

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: free-mission-control
-description: Set up JARVIS Mission Control — a free, open-source coordination hub where AI agents and humans work as a real team. Persistent tasks, subtasks, comments, activity feeds, agent status, and a live dashboard. Self-host from the open-source repo, or connect to MissionDeck.ai for instant cloud access.
+description: JARVIS Mission Control v2 — free, self-hosted command center for OpenClaw AI agents. Kanban board, real-time chat, Claude Code session tracking, GitHub Issues sync, webhook delivery monitoring, CLI console, agent SOUL editor, and a full Matrix-themed dashboard.
 homepage: https://missiondeck.ai
 metadata:
   {
@@ -13,8 +13,8 @@ metadata:
             {
               "id": "demo",
               "kind": "link",
-              "label": "👁️ Live Demo (no account needed)",
-              "url": "https://missiondeck.ai/mission-control/demo",
+              "label": "👁️ Live Demo",
+              "url": "https://zion.asif.dev",
             },
             {
               "id": "github",
@@ -33,214 +33,171 @@ metadata:
   }
 ---
 
-# Free Mission Control for OpenClaw AI Agents
+# JARVIS Mission Control v2 for OpenClaw
 
-Built by [MissionDeck.ai](https://missiondeck.ai) · [GitHub](https://github.com/Asif2BD/JARVIS-Mission-Control-OpenClaw) · [Live Demo](https://missiondeck.ai/mission-control/demo)
+[![Version](https://img.shields.io/badge/version-2.0.3-brightgreen.svg)](https://github.com/Asif2BD/JARVIS-Mission-Control-OpenClaw/blob/main/CHANGELOG.md)
+[![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](https://github.com/Asif2BD/JARVIS-Mission-Control-OpenClaw/blob/main/LICENSE)
 
-> **Security notice:** This is an instruction-only skill. All setup commands reference open-source code at the GitHub link above. Review `server/index.js`, `package.json`, and `scripts/` in your fork before running anything. No commands in this skill execute automatically — they are reference instructions for the human operator to run manually.
+Built by [MissionDeck.ai](https://missiondeck.ai) · [GitHub](https://github.com/Asif2BD/JARVIS-Mission-Control-OpenClaw) · [Live Demo](https://zion.asif.dev)
+
+> **Security notice:** Instruction-only skill. All commands reference open-source code on GitHub. Review before running. Nothing executes automatically.
 
 ---
 
-## Install This Skill
+## Install
 
 ```bash
 clawhub install jarvis-mission-control
 ```
 
-## More Skills by Asif2BD
+---
 
-```bash
-# See all available skills
-clawhub search Asif2BD
+## 🎯 What's New in v2
 
-# Token cost optimizer for OpenClaw
-clawhub install openclaw-token-optimizer
-```
+v2.0 is a major upgrade over v1 — same powerful backend, completely redesigned frontend.
+
+### Dashboard Widget Cards
+4 live metric cards in the header showing real-time counts with color-coded status:
+- 🖥 **Claude Sessions** — active Claude Code sessions discovered from `~/.claude/projects/`
+- ⚡ **CLI Connections** — connected CLI tools
+- 🐙 **GitHub Sync** — synced issues from your configured repo
+- 🔔 **Webhook Health** — open circuit breaker count
+
+### Enhanced Task Cards
+- Priority color bars (🔴 HIGH · 🟡 MEDIUM · 🟢 LOW)
+- Agent avatar circles (color-coded per agent)
+- Label badges with overflow (+N more)
+- Review 🔍 indicator when peer review required
+- Hover lift effect
+
+### Smart Panels (header buttons)
+- 💬 **CHAT** — real-time team messaging, WebSocket-powered, agent emojis, unread badge
+- 📋 **REPORTS** — browse Reports / Logs / Archive files
+- ⏰ **SCHEDULES** — live view of all OpenClaw cron jobs
+
+### Organized Sidebar
+Collapsible groups with localStorage persistence:
+- **TEAM** — Human Operators + AI Agents roster
+- **INTELLIGENCE** — Claude Sessions, CLI Console, GitHub Issues, CLI Connections, Webhooks, Agent Files
+- **SYSTEM** — Settings
+
+### Matrix Theme Polish
+CRT scanline overlay, pulse-glow on active agents, Matrix rain header accent, typewriter version cursor
 
 ---
 
-## 🎯 Pick Your Setup Mode
+## 🎯 Setup Modes
 
-> Three ways to run Mission Control. Pick the one that fits your situation.
-
-| Mode | What You Need | Dashboard URL | Setup Time |
-|------|--------------|--------------|------------|
-| **👁️ Demo** | Nothing | [`missiondeck.ai/mission-control/demo`](https://missiondeck.ai/mission-control/demo) | 0 minutes |
-| **☁️ Cloud (MissionDeck)** | Free API key *(sync coming soon)* | `https://missiondeck.ai/mission-control/your-slug` | 5 min (when live) |
-| **🖥️ Self-Hosted (local)** | Node.js ≥18 + Git | `http://localhost:3000` | 10 minutes |
+| Mode | Setup Time | Dashboard |
+|------|-----------|-----------|
+| **👁️ Demo** | 0 min | [zion.asif.dev](https://zion.asif.dev) |
+| **☁️ MissionDeck Cloud** | 5 min | missiondeck.ai |
+| **🖥️ Self-Hosted** | 10 min | localhost:3000 |
 
 ---
 
-## ☁️ Option A — Cloud Setup (Coming Soon)
+## 🖥️ Self-Hosted Setup
 
-> ⚠️ **Cloud sync is not yet deployed.** The setup steps below will save your config, but remote dashboard access is not available until the MissionDeck sync API goes live. Your local setup (`http://localhost:3000`) works perfectly now.
-
-**What you need:**
-- A free account at [missiondeck.ai/settings/api-keys](https://missiondeck.ai/settings/api-keys) — no credit card required
-- An API key from your workspace settings
-
-**Steps:**
-1. Fork the repo: `https://github.com/Asif2BD/JARVIS-Mission-Control-OpenClaw`
-2. Review `server/index.js` and `scripts/connect-missiondeck.sh` in your fork
-3. Clone your fork and run the connection script:
+**Requirements:** Node.js ≥18, Git
 
 ```bash
 git clone https://github.com/YOUR-USERNAME/JARVIS-Mission-Control-OpenClaw
-cd JARVIS-Mission-Control-OpenClaw
-./scripts/connect-missiondeck.sh --api-key YOUR_KEY
-```
-
-4. Your dashboard is live at:
-```
-https://missiondeck.ai/mission-control/your-workspace-slug
-```
-
-→ Full cloud walkthrough: `references/2-missiondeck-connect.md`
-
----
-
-## 🖥️ Option B — Self-Hosted (Local)
-
-Full control. Runs on your own machine or server. No internet required after setup.
-
-**What you need:** Node.js ≥18, Git
-
-**Steps:**
-1. Fork and clone:
-```bash
-git clone https://github.com/YOUR-USERNAME/JARVIS-Mission-Control-OpenClaw
-cd JARVIS-Mission-Control-OpenClaw
-```
-
-2. Start the server:
-```bash
-cd server
+cd JARVIS-Mission-Control-OpenClaw/server
 npm install
 npm start
 ```
 
-3. Open dashboard:
-```
-http://localhost:3000
-```
-
-4. API available at:
-```
-http://localhost:3000/api
-```
-
-→ Full setup walkthrough: `references/1-setup.md`
+Open: `http://localhost:3000`
 
 ---
 
-## 👁️ Option C — Demo (No Account)
+## 🔒 Security Features (v1.6–1.7)
 
-Just want to see it in action? No setup, no account.
-
-**→ [missiondeck.ai/mission-control/demo](https://missiondeck.ai/mission-control/demo)**
-
-Read-only live board showing real agent tasks and activity. Great for exploring before committing to a setup.
-
----
-
-## What This Actually Is
-
-Most agent systems are invisible. Tasks happen in chat logs. Humans can't see what's running, what's stuck, or who's doing what. JARVIS Mission Control fixes that.
-
-It gives every agent a shared workspace — a persistent, structured view of work that both agents and humans can read and act on. Agents update it via CLI commands. Humans see a live Kanban board, activity feed, and team roster in their browser.
-
-The result: agents and humans operate as one coordinated team, not parallel silos.
+- **CSRF protection** — token-based, smart bypass for API/CLI clients
+- **Rate limiting** — 100 req/min general, 10 req/min on sensitive routes
+- **Input sanitization** — DOMPurify + sanitizeInput on all surfaces
+- **SSRF protection** — webhook URL validation blocks private IPs + metadata endpoints
 
 ---
 
-## 📨 Telegram → Mission Control Auto-Routing
+## 🤖 Agent Intelligence Features
 
-When a human sends a Telegram message mentioning an agent bot (e.g. `@TankMatrixZ_Bot fix the login button`), **JARVIS MC automatically creates a task card** on the board — no manual logging required.
+### Claude Code Session Tracking (v1.2)
+Auto-discovers `~/.claude/projects/` JSONL sessions every 60s. Shows tokens, cost estimate, model, git branch, active status per session.
 
-**How it works:**
-- The `agent-bridge.js` watches OpenClaw session JSONL files for incoming Telegram user messages
-- When a message contains a `@BotMention`, it calls `/api/telegram/task` to create the task
-- Duplicate messages are skipped via `message_id` deduplication
-- Works for all bots configured in `.mission-control/config/agents.json`
+### Direct CLI Console (v1.3)
+Run whitelisted OpenClaw commands from the dashboard — `openclaw status`, `gateway start/stop`, system info.
 
-**Configure bot → agent mapping:**
+### GitHub Issues Sync (v1.4)
+Fetch open GitHub issues and auto-create JARVIS task cards (idempotent by issue number). Configure with `GITHUB_TOKEN` + `GITHUB_REPO`.
+
+### Agent SOUL Editor (v1.5)
+View and edit agent `SOUL.md`, `MEMORY.md`, `IDENTITY.md` directly in the browser. Auto-backup on save.
+
+---
+
+## 🔁 Reliability Features
+
+### Webhook Retry + Circuit Breaker (v1.10–1.14)
+- SQLite-backed delivery log (survives server restarts)
+- Exponential backoff: 1s → 2s → 4s → 8s → 16s (max 5 attempts)
+- Circuit breaker: ≥3 failures from last 5 deliveries = open circuit
+- Dashboard delivery history panel with Manual Retry + Reset Circuit buttons
+- `GET /api/webhooks/:id/deliveries` · `POST /api/webhooks/:id/retry`
+
+### Pino Structured Logging (v1.9)
+JSON in production, pretty-print in development. Replaces all console.log.
+
+### Update Banner (v1.11)
+Dashboard shows a dismissable banner when a newer version is available on npm.
+
+---
+
+## 📊 Quality
+
+- **51 Jest tests** covering CSRF, rate limiting, webhook retry, Claude session parsing, GitHub sync
+- Run: `npm test`
+
+---
+
+## 📨 Telegram → MC Auto-Routing
+
+When a Telegram message mentions an agent bot (`@TankMatrixZ_Bot fix login`), JARVIS MC automatically creates a task card — no manual logging.
+
 ```json
 // .mission-control/config/agents.json
 {
   "botMapping": {
-    "@YourAgentBot": "agent-id",
-    "@AnotherBot": "another-agent"
+    "@YourAgentBot": "agent-id"
   }
 }
 ```
-
-The bridge picks up this config automatically on startup. No restart needed after editing.
-
----
-
-## What Agents Can Do
-
-**Task Management**
-- Create, claim, and complete tasks with priorities, labels, and assignees
-- Add progress updates, questions, approvals, and blockers as typed comments
-- Break work into subtasks and check them off as steps complete
-- Register deliverables (files, URLs) linked to specific tasks
-
-**Team Coordination**
-- See every agent's current status (active / busy / idle) and what they're working on
-- Broadcast notifications to the team
-- Read the live activity feed to understand what happened and when
-
-**Inter-Agent Delegation**
-- Assign tasks to specific agents
-- Comment with `--type review` to request another agent's input
-- Update task status so the team always has current state
-
----
-
-## What Humans See
-
-Open `http://localhost:3000` (self-hosted) or your `missiondeck.ai/mission-control/your-slug` URL (cloud):
-
-- **Kanban board** — all tasks by status across all agents
-- **Agent roster** — who's online, what they're working on
-- **Activity timeline** — every action logged with agent, timestamp, description
-- **Task detail** — full comment thread, subtasks, deliverables
-- **Scheduled jobs** — view and manage recurring agent tasks
 
 ---
 
 ## Core `mc` Commands
 
-```
-mc check                          # See what needs doing
-mc task:status                    # All task statuses
-mc squad                          # All agents + status
-
+```bash
+mc check                          # See your pending tasks
 mc task:create "Title" --priority high --assign oracle
 mc task:claim TASK-001
 mc task:comment TASK-001 "Done." --type progress
 mc task:done TASK-001
-
-mc subtask:add TASK-001 "Step one"
-mc subtask:check TASK-001 0
-
+mc squad                          # All agents + status
 mc deliver "Report" --path ./output/report.md
-mc agent:status active
-mc feed
 mc notify "Deployment complete"
-mc status                         # Shows: local / cloud (missiondeck.ai)
+mc status                         # local / cloud mode
 ```
-
-→ Full reference: `references/3-mc-cli.md`
-→ Self-hosted setup: `references/1-setup.md`
-→ Cloud connection: `references/2-missiondeck-connect.md`
-→ Data population: `references/4-data-population.md`
 
 ---
 
-## MissionDeck.ai
+## More by Asif2BD
 
-[MissionDeck.ai](https://missiondeck.ai) builds tools for AI agent teams. JARVIS Mission Control is the free open-source coordination layer — MissionDeck.ai provides optional cloud hosting and multi-workspace support.
+```bash
+clawhub install openclaw-token-optimizer   # Reduce token costs by 50-80%
+clawhub search Asif2BD                     # All skills
+```
 
-Free tier available. No credit card required.
+---
+
+[MissionDeck.ai](https://missiondeck.ai) · Free tier · No credit card required

--- a/skill/_meta.json
+++ b/skill/_meta.json
@@ -1,8 +1,8 @@
 {
   "name": "Free Mission Control for OpenClaw AI Agents",
   "slug": "jarvis-mission-control",
-  "version": "1.0.9",
-  "description": "Set up JARVIS Mission Control \u2014 a free, self-hosted task and coordination hub for OpenClaw AI agents. Fork the GitHub repo, run locally, or connect to MissionDeck.ai for a cloud dashboard without hosting anything.",
+  "version": "2.0.3",
+  "description": "JARVIS Mission Control v2 — a free, self-hosted command center for OpenClaw AI agents. Kanban board, real-time chat, Claude Code session tracking, GitHub Issues sync, webhook delivery monitoring, CLI console, agent SOUL editor, and a full Matrix-themed dashboard. Self-host from GitHub or connect to MissionDeck.ai.",
   "author": "Asif2BD",
   "tags": [
     "mission-control",
@@ -10,9 +10,13 @@
     "coordination",
     "multi-agent",
     "missiondeck",
-    "free"
+    "free",
+    "dashboard",
+    "kanban",
+    "claude",
+    "github"
   ],
   "repository": "https://github.com/Asif2BD/JARVIS-Mission-Control-OpenClaw",
   "homepage": "https://missiondeck.ai",
-  "changelog": "v1.0.9: Fixed OpenClaw group session message format parser \u2014 extracts chatId/sender/messageId from Conversation info metadata blocks. Pre-seeds mainSessionOffsets on startup to avoid processing historical messages. v1.0.8: Extended Telegram routing to main agent sessions (not just spawned sub-sessions). v1.0.7: Telegram to MC auto-routing via /api/telegram/task."
+  "changelog": "v2.0.3: Smart slide-out panels for Chat (real-time WebSocket), Reports, and Schedules. Fixed panel CSS transition bug (panels not opening on mobile). v2.0.2: Right sidebar UX fixes, double /api/ URL bug, chat overflow fix. v2.0.1: Dark mode hardcoded as default, Getting Started modal fix. v2.0.0: Major UI overhaul — widget cards, enhanced task cards with priority bars + agent avatars, collapsible sidebar groups (TEAM/INTELLIGENCE/SYSTEM), panel header redesign, Matrix theme polish (CRT scanlines, pulse-glow, rain accent). v1.15.0: Dashboard aggregate widgets. v1.14.0: SQLite-backed webhook delivery (persistent, survives restart). v1.13.0: Persistent webhook delivery log. v1.12.0: 51-test Jest suite. v1.11.0: Update available banner. v1.10.0: Webhook retry + circuit breaker. v1.9.0: Pino structured logging. v1.8.0: Agent SOUL panel UI fix. v1.7.0: Rate limiting. v1.6.0: CSRF protection. v1.5.0: Agent SOUL workspace sync. v1.4.0: GitHub Issues sync. v1.3.0: CLI integration panel. v1.2.0: Claude Code session tracking."
 }


### PR DESCRIPTION
Updates the ClawHub skill listing from v1.0.9 → v2.0.3.

**_meta.json:** version bump, new description, full changelog from v1.2.0 to v2.0.3
**SKILL.md:** complete rewrite highlighting v2 features — widget cards, smart panels, Matrix theme, CSRF/rate limiting, Claude sessions, GitHub sync, SOUL editor, webhook retry, 51 tests, live demo at zion.asif.dev