### PR TITLE
feat: JARVIS experience — two-way voice + cinematic Iron Man HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format: [version] — date | what changed | PR
 
 ---
 
+## [Unreleased] — JARVIS Voice & Cinematic HUD
+
+### Added
+- 🎙️ **Two-way voice (JARVIS Voice)** — `dashboard/js/jarvis-voice.js`. Speaks via the Web Speech API (auto-selects a British English voice to match the films) and listens for spoken commands via `SpeechRecognition`. Degrades gracefully: speech output works everywhere; voice commands light up in Chrome/Edge and stay silent elsewhere.
+  - Commands: status report, open chat/reports/schedules/events/GitHub, "create task …", switch theme (jarvis/matrix), mute/unmute, greeting.
+  - Event announcements wired to the live WebSocket bus: new task, task DONE/BLOCKED, review submitted/approved, quota exceeded, uplink lost/restored.
+- 🌀 **Cinematic HUD (JARVIS mode)** — `dashboard/js/jarvis-hud.js` + `dashboard/css/jarvis-hud.css`. Power-up boot sequence ("INITIALIZING JARVIS…"), animated arc-reactor (header logo + boot centerpiece), ambient HUD chrome (corner reticles, sweeping scan line, grid vignette), a reactive voice dock (orb + waveform + mic/mute), and live subtitles of what JARVIS says/hears.
+- 🎨 **Arc-reactor blue is now the default theme** — `data-color-theme="jarvis"` with a no-flash early init. Matrix and all other themes remain selectable; JARVIS mode is toggleable (`window.toggleJarvisMode()` / the dock power button) and persisted in `localStorage`.
+- ♿ Respects `prefers-reduced-motion`; all HUD overlays are `pointer-events:none` so they never block the UI.
+
+---
+
 ## [2.1.0] — 2026-06-21 | OpenClaw Sessions, Cost Metrics Fix & Hardening
 
 ### Added

--- a/dashboard/css/jarvis-hud.css
+++ b/dashboard/css/jarvis-hud.css
@@ -1,0 +1,344 @@
+/* ============================================================
+   JARVIS HUD — Iron Man-style cinematic layer
+   Additive overlay on top of the existing dashboard. Everything
+   cinematic is scoped to html.jarvis-mode so it can be toggled off.
+   The color palette rides on data-color-theme="jarvis".
+   ============================================================ */
+
+:root {
+    --jarvis-cyan: #00d4ff;
+    --jarvis-cyan-soft: rgba(0, 212, 255, 0.55);
+    --jarvis-gold: #ffc640;
+    --jarvis-gold-soft: rgba(255, 198, 64, 0.6);
+    --jarvis-ink: #03070f;
+    --jarvis-glow: 0 0 12px rgba(0, 212, 255, 0.55), 0 0 28px rgba(0, 212, 255, 0.25);
+    --jarvis-glow-gold: 0 0 12px rgba(255, 198, 64, 0.55), 0 0 26px rgba(255, 198, 64, 0.22);
+}
+
+/* ----------------------------------------------------------------
+   1. ARC REACTOR (reusable) — concentric rotating rings + core
+   ---------------------------------------------------------------- */
+.arc-reactor {
+    position: relative;
+    width: var(--reactor-size, 34px);
+    height: var(--reactor-size, 34px);
+    border-radius: 50%;
+    flex: 0 0 auto;
+    display: inline-grid;
+    place-items: center;
+    color: var(--jarvis-cyan);
+}
+.arc-reactor::before,
+.arc-reactor::after {
+    content: "";
+    position: absolute;
+    border-radius: 50%;
+    border: 1.5px solid currentColor;
+}
+.arc-reactor::before {
+    inset: 0;
+    border-style: solid;
+    border-top-color: transparent;
+    border-bottom-color: transparent;
+    box-shadow: var(--jarvis-glow);
+    animation: jarvis-spin 4s linear infinite;
+}
+.arc-reactor::after {
+    inset: 22%;
+    border-style: dashed;
+    border-left-color: transparent;
+    border-right-color: transparent;
+    opacity: 0.8;
+    animation: jarvis-spin 6s linear infinite reverse;
+}
+.arc-reactor .reactor-core {
+    width: 34%;
+    height: 34%;
+    border-radius: 50%;
+    background: radial-gradient(circle, #fff 0%, var(--jarvis-cyan) 55%, transparent 100%);
+    box-shadow: var(--jarvis-glow);
+    animation: jarvis-pulse 2.6s ease-in-out infinite;
+}
+
+@keyframes jarvis-spin { to { transform: rotate(360deg); } }
+@keyframes jarvis-pulse {
+    0%, 100% { opacity: 0.65; transform: scale(0.9); }
+    50%      { opacity: 1;    transform: scale(1.1); }
+}
+
+/* Header logo becomes a small arc reactor in JARVIS mode */
+html.jarvis-mode .logo-icon {
+    --reactor-size: 30px;
+    background: transparent !important;
+    color: var(--jarvis-cyan);
+    box-shadow: none !important;
+    position: relative;
+}
+html.jarvis-mode .logo-icon::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    border: 1.5px solid var(--jarvis-cyan);
+    border-top-color: transparent;
+    border-bottom-color: transparent;
+    box-shadow: var(--jarvis-glow);
+    animation: jarvis-spin 4s linear infinite;
+}
+
+/* ----------------------------------------------------------------
+   2. AMBIENT HUD CHROME — corner reticles, scan line, grid vignette
+   pointer-events:none so it never blocks the UI.
+   ---------------------------------------------------------------- */
+#jarvis-hud-chrome {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 1;
+    display: none;
+}
+html.jarvis-mode #jarvis-hud-chrome { display: block; }
+
+#jarvis-hud-chrome .hud-corner {
+    position: absolute;
+    width: 64px;
+    height: 64px;
+    border: 2px solid var(--jarvis-cyan-soft);
+    opacity: 0.5;
+    filter: drop-shadow(0 0 6px rgba(0, 212, 255, 0.4));
+}
+#jarvis-hud-chrome .hud-corner.tl { top: 10px; left: 10px; border-right: 0; border-bottom: 0; }
+#jarvis-hud-chrome .hud-corner.tr { top: 10px; right: 10px; border-left: 0; border-bottom: 0; }
+#jarvis-hud-chrome .hud-corner.bl { bottom: 10px; left: 10px; border-right: 0; border-top: 0; }
+#jarvis-hud-chrome .hud-corner.br { bottom: 10px; right: 10px; border-left: 0; border-top: 0; }
+
+#jarvis-hud-chrome .hud-scanline {
+    position: absolute;
+    left: 0; right: 0; top: 0;
+    height: 140px;
+    background: linear-gradient(180deg, transparent 0%, rgba(0, 212, 255, 0.06) 50%, transparent 100%);
+    animation: jarvis-scan 7s linear infinite;
+}
+@keyframes jarvis-scan {
+    0%   { transform: translateY(-160px); }
+    100% { transform: translateY(100vh); }
+}
+
+#jarvis-hud-chrome .hud-grid {
+    position: absolute;
+    inset: 0;
+    background-image:
+        linear-gradient(rgba(0, 212, 255, 0.035) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 212, 255, 0.035) 1px, transparent 1px);
+    background-size: 46px 46px;
+    mask-image: radial-gradient(ellipse at center, transparent 35%, #000 100%);
+    -webkit-mask-image: radial-gradient(ellipse at center, transparent 35%, #000 100%);
+}
+
+/* ----------------------------------------------------------------
+   3. BOOT SEQUENCE — full-screen power-up
+   ---------------------------------------------------------------- */
+#jarvis-boot {
+    position: fixed;
+    inset: 0;
+    z-index: 100000;
+    display: none;
+    place-items: center;
+    background: radial-gradient(ellipse at center, #06121f 0%, var(--jarvis-ink) 70%, #000 100%);
+    font-family: 'Orbitron', sans-serif;
+    color: var(--jarvis-cyan);
+    text-align: center;
+}
+#jarvis-boot.show { display: grid; }
+#jarvis-boot.fade-out { animation: jarvis-boot-fade 900ms ease forwards; }
+@keyframes jarvis-boot-fade { to { opacity: 0; visibility: hidden; } }
+
+#jarvis-boot .boot-reactor {
+    --reactor-size: 160px;
+    margin: 0 auto 28px;
+    animation: jarvis-boot-grow 1200ms cubic-bezier(.2,.8,.2,1) both;
+}
+@keyframes jarvis-boot-grow {
+    from { transform: scale(0.2); opacity: 0; filter: blur(8px); }
+    to   { transform: scale(1);   opacity: 1; filter: blur(0); }
+}
+#jarvis-boot .boot-title {
+    font-size: clamp(28px, 6vw, 64px);
+    font-weight: 900;
+    letter-spacing: 0.42em;
+    text-indent: 0.42em;
+    margin: 0 0 18px;
+    text-shadow: var(--jarvis-glow);
+}
+#jarvis-boot .boot-log {
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 13px;
+    line-height: 1.9;
+    color: var(--jarvis-cyan-soft);
+    min-height: 120px;
+    text-align: left;
+    width: min(440px, 86vw);
+    margin: 0 auto;
+}
+#jarvis-boot .boot-log .ok { color: var(--jarvis-gold); }
+#jarvis-boot .boot-skip {
+    margin-top: 22px;
+    font-family: 'Rajdhani', sans-serif;
+    font-size: 12px;
+    letter-spacing: 0.2em;
+    color: var(--text-muted, #64748b);
+    cursor: pointer;
+    pointer-events: auto;
+    background: none;
+    border: 1px solid var(--border-color, #1e3a5f);
+    padding: 6px 16px;
+    border-radius: 4px;
+}
+#jarvis-boot .boot-skip:hover { color: var(--jarvis-cyan); border-color: var(--jarvis-cyan); }
+
+/* ----------------------------------------------------------------
+   4. VOICE DOCK — mic + mute + status, with a reactive orb
+   ---------------------------------------------------------------- */
+#jarvis-dock {
+    position: fixed;
+    right: 18px;
+    bottom: 18px;
+    z-index: 9000;
+    display: none;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    border-radius: 999px;
+    background: rgba(8, 20, 34, 0.82);
+    border: 1px solid var(--border-color, #1e3a5f);
+    box-shadow: var(--jarvis-glow), 0 8px 30px rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(10px);
+    font-family: 'Rajdhani', sans-serif;
+}
+html.jarvis-mode #jarvis-dock { display: flex; }
+
+#jarvis-dock .dock-orb {
+    --reactor-size: 30px;
+    transition: filter 0.2s ease;
+}
+#jarvis-dock.speaking .dock-orb { filter: drop-shadow(0 0 10px var(--jarvis-cyan)); }
+#jarvis-dock.listening .dock-orb { color: var(--jarvis-gold); }
+
+#jarvis-dock .dock-status {
+    font-size: 13px;
+    letter-spacing: 0.08em;
+    color: var(--text-secondary, #94a3b8);
+    min-width: 92px;
+    max-width: 220px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+#jarvis-dock .dock-status.active { color: var(--jarvis-cyan); }
+
+#jarvis-dock button {
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    background: rgba(0, 212, 255, 0.08);
+    border: 1px solid var(--border-color, #1e3a5f);
+    color: var(--jarvis-cyan);
+    font-size: 16px;
+    transition: all 0.18s ease;
+}
+#jarvis-dock button:hover { background: rgba(0, 212, 255, 0.18); box-shadow: var(--jarvis-glow); }
+#jarvis-dock button.off { color: var(--text-muted, #64748b); border-color: var(--border-subtle, #0f2847); }
+#jarvis-dock button.mic.listening {
+    color: var(--jarvis-gold);
+    border-color: var(--jarvis-gold);
+    box-shadow: var(--jarvis-glow-gold);
+    animation: jarvis-pulse 1.4s ease-in-out infinite;
+}
+
+/* Waveform bars shown while JARVIS is speaking */
+#jarvis-dock .dock-wave { display: none; gap: 2px; align-items: flex-end; height: 20px; }
+#jarvis-dock.speaking .dock-wave { display: flex; }
+#jarvis-dock .dock-wave span {
+    width: 3px; height: 6px;
+    background: var(--jarvis-cyan);
+    border-radius: 2px;
+    animation: jarvis-wave 0.9s ease-in-out infinite;
+}
+#jarvis-dock .dock-wave span:nth-child(2) { animation-delay: 0.15s; }
+#jarvis-dock .dock-wave span:nth-child(3) { animation-delay: 0.30s; }
+#jarvis-dock .dock-wave span:nth-child(4) { animation-delay: 0.45s; }
+#jarvis-dock .dock-wave span:nth-child(5) { animation-delay: 0.60s; }
+@keyframes jarvis-wave { 0%,100% { height: 5px; } 50% { height: 20px; } }
+
+/* Transient subtitle of what JARVIS just said / heard */
+#jarvis-subtitle {
+    position: fixed;
+    left: 50%;
+    bottom: 74px;
+    transform: translateX(-50%);
+    z-index: 9000;
+    max-width: min(680px, 92vw);
+    padding: 8px 18px;
+    border-radius: 8px;
+    background: rgba(8, 20, 34, 0.9);
+    border: 1px solid var(--border-color, #1e3a5f);
+    color: var(--jarvis-cyan);
+    font-family: 'Rajdhani', sans-serif;
+    font-size: 15px;
+    letter-spacing: 0.03em;
+    text-align: center;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+}
+#jarvis-subtitle.show { opacity: 1; }
+#jarvis-subtitle .who { color: var(--jarvis-gold); font-weight: 600; margin-right: 8px; }
+
+/* ----------------------------------------------------------------
+   5. Accessibility — respect reduced motion
+   ---------------------------------------------------------------- */
+/* Re-enable launcher — only visible when JARVIS mode is OFF */
+#jarvis-enable {
+    position: fixed;
+    right: 18px;
+    bottom: 18px;
+    z-index: 9000;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px 8px 10px;
+    border-radius: 999px;
+    cursor: pointer;
+    background: rgba(8, 20, 34, 0.82);
+    border: 1px solid var(--border-color, #1e3a5f);
+    color: var(--jarvis-cyan);
+    font-family: 'Rajdhani', sans-serif;
+    font-size: 13px;
+    letter-spacing: 0.08em;
+    backdrop-filter: blur(8px);
+}
+#jarvis-enable:hover { box-shadow: var(--jarvis-glow); }
+#jarvis-enable .arc-reactor { --reactor-size: 24px; }
+html.jarvis-mode #jarvis-enable { display: none; }
+
+/* ----------------------------------------------------------------
+   5. Accessibility — respect reduced motion
+   ---------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+    .arc-reactor::before, .arc-reactor::after, .arc-reactor .reactor-core,
+    html.jarvis-mode .logo-icon::after,
+    #jarvis-hud-chrome .hud-scanline,
+    #jarvis-dock .dock-wave span,
+    #jarvis-dock button.mic.listening {
+        animation: none !important;
+    }
+}
+
+@media (max-width: 640px) {
+    #jarvis-hud-chrome .hud-corner { width: 40px; height: 40px; }
+    #jarvis-dock .dock-status { display: none; }
+    #jarvis-dock { right: 10px; bottom: 70px; padding: 8px 10px; }
+}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -15,6 +15,20 @@
     <link rel="stylesheet" href="./css/events-feed.css">
     <link rel="stylesheet" href="./css/themes.css">
     <link rel="stylesheet" href="./css/mobile.css">
+    <link rel="stylesheet" href="./css/jarvis-hud.css">
+    <!-- JARVIS no-flash init: apply HUD mode + default arc-reactor theme before first paint -->
+    <script>
+      (function () {
+        try {
+          if (localStorage.getItem('jarvis-mode') !== 'off') {
+            document.documentElement.classList.add('jarvis-mode');
+          }
+          if (!localStorage.getItem('mc-color-theme')) {
+            document.documentElement.setAttribute('data-color-theme', 'jarvis');
+          }
+        } catch (e) {}
+      })();
+    </script>
 </head>
 <body>
     <!-- Mobile Sidebar Overlay -->
@@ -1622,6 +1636,9 @@
     <script src="./js/update-banner.js"></script>
     <script src="./js/smart-panels.js"></script>
     <script src="./js/events-feed.js"></script>
+    <!-- JARVIS experience — voice engine + cinematic HUD (load last) -->
+    <script src="./js/jarvis-voice.js"></script>
+    <script src="./js/jarvis-hud.js"></script>
     <script>
     // Stubs for removed floating chat — prevent old JS from throwing
     function toggleChatPanel() { openChatPanel(); }

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -44,7 +44,7 @@ function toggleSidebarGroup(groupId) {
 // State
 let selectedTask = null;
 let currentTheme = 'dark';
-let currentColorTheme = 'matrix';
+let currentColorTheme = 'jarvis'; // JARVIS arc-reactor blue is the default look
 let currentProfileAgent = null;
 let currentProfileTab = 'attention';
 let currentThreadId = null;

--- a/dashboard/js/jarvis-hud.js
+++ b/dashboard/js/jarvis-hud.js
@@ -132,7 +132,13 @@
       document.documentElement.classList.toggle('jarvis-mode', on);
       localStorage.setItem('jarvis-mode', on ? 'on' : 'off');
       if (on && !sessionStorage.getItem('jarvis-booted')) this.boot();
+      // Powering off must be immediate: stop any in-flight speech/listening.
+      if (!on) {
+        try { window.speechSynthesis && window.speechSynthesis.cancel(); } catch (e) {}
+        if (V() && V().listening) V().stopListening();
+      }
     },
+    isActive() { return document.documentElement.classList.contains('jarvis-mode'); },
     toggleMode() {
       this.setMode(!document.documentElement.classList.contains('jarvis-mode'));
     },
@@ -186,6 +192,9 @@
       if (!api || typeof api.on !== 'function') return;
       let last = 0;
       const announce = (text, priority) => {
+        // Stay silent when JARVIS mode is powered off — the handlers remain
+        // registered, so this gate is what makes the power toggle reliable.
+        if (!this.isActive()) return;
         const now = Date.now();
         if (now - last < 1200 && !priority) return; // throttle chatter
         last = now;

--- a/dashboard/js/jarvis-hud.js
+++ b/dashboard/js/jarvis-hud.js
@@ -1,0 +1,318 @@
+/**
+ * JARVIS HUD — the cinematic layer that ties it together.
+ *
+ *  - Injects the boot overlay, ambient HUD chrome, voice dock and subtitle.
+ *  - Runs the power-up boot sequence (once per browser session).
+ *  - Announces Mission Control events through JarvisVoice.
+ *  - Parses spoken commands and drives the dashboard.
+ *
+ * Toggle the whole experience with window.toggleJarvisMode(). The arc-reactor
+ * color theme (data-color-theme="jarvis") is independent and set in app.js.
+ */
+(function () {
+  'use strict';
+
+  const V = () => window.JarvisVoice;
+
+  const JarvisHud = {
+    booted: false,
+
+    init() {
+      this._injectDom();
+      if (V()) {
+        V().init();
+        V().commandHandler = (t) => this.handleCommand(t);
+      }
+      this._wireSpeechVisuals();
+      this._wireDockControls();
+      this._wireEventAnnouncements();
+      // Boot once per session, only when JARVIS mode is on.
+      if (document.documentElement.classList.contains('jarvis-mode')
+          && !sessionStorage.getItem('jarvis-booted')) {
+        this.boot();
+      }
+    },
+
+    // ---- DOM ----------------------------------------------------
+
+    _injectDom() {
+      if (document.getElementById('jarvis-boot')) return;
+      const reactor = '<span class="arc-reactor"><span class="reactor-core"></span></span>';
+
+      const boot = document.createElement('div');
+      boot.id = 'jarvis-boot';
+      boot.innerHTML =
+        `<div>
+           <div class="boot-reactor arc-reactor"><span class="reactor-core"></span></div>
+           <h1 class="boot-title">JARVIS</h1>
+           <div class="boot-log" id="jarvis-boot-log"></div>
+           <button class="boot-skip" id="jarvis-boot-skip">SKIP ›</button>
+         </div>`;
+
+      const chrome = document.createElement('div');
+      chrome.id = 'jarvis-hud-chrome';
+      chrome.innerHTML =
+        `<div class="hud-grid"></div>
+         <div class="hud-scanline"></div>
+         <div class="hud-corner tl"></div><div class="hud-corner tr"></div>
+         <div class="hud-corner bl"></div><div class="hud-corner br"></div>`;
+
+      const dock = document.createElement('div');
+      dock.id = 'jarvis-dock';
+      dock.innerHTML =
+        `<span class="dock-orb arc-reactor" title="Replay boot sequence">${'<span class="reactor-core"></span>'}</span>
+         <div class="dock-wave"><span></span><span></span><span></span><span></span><span></span></div>
+         <span class="dock-status" id="jarvis-status">JARVIS online</span>
+         <button class="mic" id="jarvis-mic" title="Speak a command">🎙️</button>
+         <button class="mute" id="jarvis-mute" title="Mute voice">🔊</button>
+         <button class="power" id="jarvis-power" title="Exit JARVIS mode">⏻</button>`;
+
+      const sub = document.createElement('div');
+      sub.id = 'jarvis-subtitle';
+
+      const enable = document.createElement('div');
+      enable.id = 'jarvis-enable';
+      enable.title = 'Enable JARVIS mode';
+      enable.innerHTML = `${reactor}<span>ENABLE JARVIS</span>`;
+      enable.addEventListener('click', () => this.setMode(true));
+
+      document.body.append(boot, chrome, dock, sub, enable);
+
+      // Hide the mic button entirely where speech recognition is unsupported.
+      if (V() && !V().supportsInput()) {
+        const mic = document.getElementById('jarvis-mic');
+        if (mic) mic.style.display = 'none';
+      }
+    },
+
+    // ---- Boot sequence ------------------------------------------
+
+    boot(force) {
+      if (this.booted && !force) return;
+      this.booted = true;
+      sessionStorage.setItem('jarvis-booted', '1');
+      const overlay = document.getElementById('jarvis-boot');
+      const log = document.getElementById('jarvis-boot-log');
+      if (!overlay || !log) return;
+      log.innerHTML = '';
+      overlay.classList.remove('fade-out');
+      overlay.classList.add('show');
+
+      const lines = [
+        'Initializing JARVIS core…',
+        'Loading Mission Control modules…',
+        'Establishing real-time uplink…',
+        'Calibrating agent telemetry…',
+        'Diagnostics: <span class="ok">ALL SYSTEMS NOMINAL</span>',
+      ];
+      let i = 0;
+      const finish = () => {
+        overlay.classList.add('fade-out');
+        setTimeout(() => overlay.classList.remove('show', 'fade-out'), 900);
+        if (V()) V().greeting();
+        this.setStatus('JARVIS online', false);
+      };
+      const tick = () => {
+        if (i >= lines.length) { setTimeout(finish, 600); return; }
+        const div = document.createElement('div');
+        div.innerHTML = `<span style="color:var(--jarvis-gold)">›</span> ${lines[i]}`;
+        log.appendChild(div);
+        i++;
+        setTimeout(tick, 480);
+      };
+      tick();
+
+      const skip = document.getElementById('jarvis-boot-skip');
+      if (skip) skip.onclick = () => { i = lines.length; finish(); };
+    },
+
+    // ---- Mode toggle --------------------------------------------
+
+    setMode(on) {
+      document.documentElement.classList.toggle('jarvis-mode', on);
+      localStorage.setItem('jarvis-mode', on ? 'on' : 'off');
+      if (on && !sessionStorage.getItem('jarvis-booted')) this.boot();
+    },
+    toggleMode() {
+      this.setMode(!document.documentElement.classList.contains('jarvis-mode'));
+    },
+
+    // ---- Voice <-> visuals --------------------------------------
+
+    _wireSpeechVisuals() {
+      const dock = () => document.getElementById('jarvis-dock');
+      window.addEventListener('jarvis:speaking-start', (e) => {
+        dock() && dock().classList.add('speaking');
+        this.subtitle('JARVIS', e.detail && e.detail.text);
+      });
+      window.addEventListener('jarvis:speaking-end', () => dock() && dock().classList.remove('speaking'));
+      window.addEventListener('jarvis:listening-start', () => {
+        dock() && dock().classList.add('listening');
+        const mic = document.getElementById('jarvis-mic');
+        mic && mic.classList.add('listening');
+        this.setStatus('Listening…', true);
+      });
+      window.addEventListener('jarvis:listening-end', () => {
+        dock() && dock().classList.remove('listening');
+        const mic = document.getElementById('jarvis-mic');
+        mic && mic.classList.remove('listening');
+        this.setStatus('JARVIS online', false);
+      });
+      window.addEventListener('jarvis:heard', (e) => {
+        this.subtitle('You', e.detail && e.detail.transcript);
+      });
+    },
+
+    _wireDockControls() {
+      const on = (id, fn) => { const el = document.getElementById(id); if (el) el.onclick = fn; };
+      on('jarvis-mic', () => V() && V().toggleListening());
+      on('jarvis-mute', () => {
+        const enabled = V() ? V().toggle() : false;
+        const btn = document.getElementById('jarvis-mute');
+        if (btn) { btn.textContent = enabled ? '🔊' : '🔇'; btn.classList.toggle('off', !enabled); }
+      });
+      on('jarvis-power', () => this.setMode(false));
+      const orb = document.querySelector('#jarvis-dock .dock-orb');
+      if (orb) orb.onclick = () => this.boot(true);
+      // Reflect persisted mute state on load.
+      const mute = document.getElementById('jarvis-mute');
+      if (mute && V() && !V().enabled) { mute.textContent = '🔇'; mute.classList.add('off'); }
+    },
+
+    // ---- Event announcements ------------------------------------
+
+    _wireEventAnnouncements() {
+      const api = window.MissionControlAPI;
+      if (!api || typeof api.on !== 'function') return;
+      let last = 0;
+      const announce = (text, priority) => {
+        const now = Date.now();
+        if (now - last < 1200 && !priority) return; // throttle chatter
+        last = now;
+        if (V()) V().speak(text, { priority });
+      };
+      // Announce DONE / BLOCKED transitions only once per task (the server emits
+      // task.updated for any change, so we de-dupe on id+status).
+      const seen = new Set();
+      const titleOf = (t) => (t && t.title ? t.title : '');
+
+      api.on('task.created', (t) => announce(`Incoming task. ${titleOf(t) || 'New task logged'}.`));
+      api.on('task.updated', (t) => {
+        if (!t || !t.id || !t.status) return;
+        const key = `${t.id}:${t.status}`;
+        if (seen.has(key)) return;
+        if (t.status === 'DONE') { seen.add(key); announce(`Task complete, sir. ${titleOf(t)}.`); }
+        else if (t.status === 'BLOCKED') { seen.add(key); announce(`Warning. A task is blocked. ${titleOf(t)}.`, true); }
+      });
+      api.on('review.submitted', () => announce('A task awaits your review, sir.'));
+      api.on('review.approved', () => announce('Review approved.'));
+      api.on('quota.exceeded', () => announce('Alert. A resource quota has been exceeded.', true));
+      api.on('message.created', (m) => { if (m && m.type === 'chat') announce('You have a new message.'); });
+      api.on('ws.disconnected', () => this.setStatus('Uplink lost — reconnecting…', false));
+      api.on('ws.connected', () => this.setStatus('JARVIS online', false));
+      api.on('ws.reconnected', () => { this.setStatus('Uplink restored', false); announce('Uplink restored.'); });
+    },
+
+    // ---- Spoken command parser ----------------------------------
+
+    /** Returns true if the transcript matched a command. */
+    handleCommand(raw) {
+      const t = (raw || '').toLowerCase().trim();
+      if (!t) return false;
+      const say = (s) => V() && V().speak(s, { priority: true });
+      const call = (fn) => { if (typeof window[fn] === 'function') { window[fn](); return true; } return false; };
+
+      // Mute / wake
+      if (/\b(mute|silence|quiet|stand down)\b/.test(t)) { V() && V().setEnabled(false); this._reflectMute(); return true; }
+      if (/\b(unmute|speak up|wake up|you there|are you there)\b/.test(t)) { V() && V().setEnabled(true); this._reflectMute(); say('At your service, sir.'); return true; }
+
+      // Status report — read live metrics from the header
+      if (/\b(status|report|sit ?rep|how are things|summary)\b/.test(t)) { this.speakStatus(); return true; }
+
+      // Theme switching
+      if (/\b(matrix)\b/.test(t)) { this._setTheme('matrix'); say('Switching to Matrix protocol.'); return true; }
+      if (/\b(jarvis|blue|arc reactor)\b/.test(t) && /\b(theme|mode|protocol|switch)\b/.test(t)) { this._setTheme('jarvis'); say('JARVIS interface engaged.'); return true; }
+
+      // Open panels
+      if (/\bchat\b/.test(t)) { say('Opening chat.'); return call('openChatPanel') || call('toggleChatPanel'); }
+      if (/\breports?\b/.test(t)) { say('Opening reports.'); return call('openReportsPanel'); }
+      if (/\b(schedules?|jobs?|cron)\b/.test(t)) { say('Opening schedules.'); return call('openSchedulesPanel'); }
+      if (/\b(events?|activity|feed)\b/.test(t)) { say('Opening the event feed.'); return call('openEventFeedPanel'); }
+      if (/\b(github|issues?)\b/.test(t)) { say('Opening GitHub issues.'); return call('openGithubPanel'); }
+
+      // Create a task — "create task <title>" / "new task <title>"
+      const m = t.match(/\b(?:create|add|new)\s+(?:a\s+)?task\s+(?:called\s+|named\s+|to\s+)?(.+)$/);
+      if (m && m[1]) { this._createTask(m[1].trim()); return true; }
+
+      // Greeting
+      if (/\b(hello|hi|hey|good (morning|afternoon|evening))\b/.test(t)) { V() && V().greeting(); return true; }
+
+      say("I'm afraid I didn't catch that, sir.");
+      return false;
+    },
+
+    speakStatus() {
+      const num = (id) => { const el = document.getElementById(id); return el ? (el.textContent || '0').trim() : '0'; };
+      const total = num('total-tasks'), prog = num('in-progress'), done = num('completed-today');
+      const msg = `Status report. ${total} tasks tracked. ${prog} in progress. ${done} completed today. All systems nominal, sir.`;
+      V() && V().speak(msg, { priority: true });
+      this.setStatus('Status report', true);
+    },
+
+    _createTask(title) {
+      const say = (s) => V() && V().speak(s, { priority: true });
+      const nice = title.charAt(0).toUpperCase() + title.slice(1);
+      const api = window.MissionControlAPI;
+      if (api && typeof api.createTask === 'function') {
+        api.createTask({ title: nice, status: 'INBOX', priority: 'medium', created_by: 'jarvis-voice' })
+          .then(() => { say(`Task created: ${nice}.`); if (typeof window.renderDashboard === 'function') window.renderDashboard(); })
+          .catch(() => say('I was unable to create that task, sir.'));
+      } else {
+        say('Task system is offline, sir.');
+      }
+    },
+
+    _setTheme(name) {
+      if (typeof window.setColorTheme === 'function') window.setColorTheme(name);
+      else document.documentElement.setAttribute('data-color-theme', name);
+    },
+    _reflectMute() {
+      const btn = document.getElementById('jarvis-mute');
+      if (btn && V()) { btn.textContent = V().enabled ? '🔊' : '🔇'; btn.classList.toggle('off', !V().enabled); }
+    },
+
+    // ---- Small helpers ------------------------------------------
+
+    setStatus(text, active) {
+      const el = document.getElementById('jarvis-status');
+      if (!el) return;
+      el.textContent = text;
+      el.classList.toggle('active', !!active);
+    },
+    subtitle(who, text) {
+      if (!text) return;
+      const el = document.getElementById('jarvis-subtitle');
+      if (!el) return;
+      el.innerHTML = `<span class="who">${who}</span>${_escape(text)}`;
+      el.classList.add('show');
+      clearTimeout(this._subTimer);
+      this._subTimer = setTimeout(() => el.classList.remove('show'), 4200);
+    },
+  };
+
+  function _escape(s) {
+    const d = document.createElement('div');
+    d.textContent = String(s);
+    return d.innerHTML;
+  }
+
+  window.JarvisHud = JarvisHud;
+  window.toggleJarvisMode = () => JarvisHud.toggleMode();
+
+  // Init after the rest of the app has wired up its API + globals.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => JarvisHud.init());
+  } else {
+    JarvisHud.init();
+  }
+})();

--- a/dashboard/js/jarvis-voice.js
+++ b/dashboard/js/jarvis-voice.js
@@ -1,0 +1,151 @@
+/**
+ * JARVIS Voice — two-way voice for Mission Control.
+ *
+ *   Output:  Web Speech API `speechSynthesis` (works in all modern browsers).
+ *            Picks a British English voice to match the films; falls back gracefully.
+ *   Input:   `SpeechRecognition` / `webkitSpeechRecognition` (Chrome/Edge).
+ *            Degrades silently where unsupported — output still works.
+ *
+ * Emits DOM CustomEvents the HUD listens to:
+ *   jarvis:speaking-start / jarvis:speaking-end  (detail: { text })
+ *   jarvis:listening-start / jarvis:listening-end
+ *   jarvis:heard  (detail: { transcript })
+ *   jarvis:command  (detail: { transcript })  — a parsed command was dispatched
+ */
+(function () {
+  'use strict';
+
+  const synth = typeof window !== 'undefined' ? window.speechSynthesis : null;
+  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+
+  const JarvisVoice = {
+    enabled: true,          // text-to-speech on/off (persisted)
+    voice: null,            // chosen SpeechSynthesisVoice
+    queue: [],
+    speaking: false,
+    listening: false,
+    recognition: null,
+    commandHandler: null,   // set by JarvisHud — (transcript) => bool handled
+
+    supportsOutput() { return !!synth; },
+    supportsInput() { return !!SpeechRecognition; },
+
+    init() {
+      this.enabled = localStorage.getItem('jarvis-voice') !== 'off';
+      if (synth) {
+        this._loadVoice();
+        // Voice list populates async in most browsers.
+        if (typeof synth.onvoiceschanged !== 'undefined') {
+          synth.onvoiceschanged = () => this._loadVoice();
+        }
+      }
+      if (SpeechRecognition) this._setupRecognition();
+      return this;
+    },
+
+    _loadVoice() {
+      if (!synth) return;
+      const voices = synth.getVoices();
+      if (!voices || !voices.length) return;
+      // Preference order — male British "JARVIS"-like voices first.
+      const prefs = [
+        'Google UK English Male',
+        'Microsoft Ryan Online (Natural) - English (United Kingdom)',
+        'Microsoft George - English (United Kingdom)',
+        'Daniel',                       // macOS en-GB male
+        'Arthur',                       // macOS en-GB
+      ];
+      for (const name of prefs) {
+        const v = voices.find(x => x.name === name);
+        if (v) { this.voice = v; return; }
+      }
+      // Any en-GB, then any English.
+      this.voice = voices.find(v => /en[-_]GB/i.test(v.lang))
+                || voices.find(v => /^en/i.test(v.lang))
+                || voices[0];
+    },
+
+    /** Speak text. opts: { priority:true clears the queue first } */
+    speak(text, opts = {}) {
+      if (!synth || !this.enabled || !text) return;
+      if (opts.priority) { synth.cancel(); this.queue = []; }
+      const u = new SpeechSynthesisUtterance(text);
+      if (this.voice) u.voice = this.voice;
+      u.lang = (this.voice && this.voice.lang) || 'en-GB';
+      u.rate = 0.98;
+      u.pitch = 0.85;   // a touch lower — calm and measured
+      u.volume = 1;
+      u.onstart = () => {
+        this.speaking = true;
+        _emit('jarvis:speaking-start', { text });
+      };
+      u.onend = u.onerror = () => {
+        this.speaking = false;
+        _emit('jarvis:speaking-end', { text });
+      };
+      synth.speak(u);
+    },
+
+    setEnabled(on) {
+      this.enabled = on;
+      localStorage.setItem('jarvis-voice', on ? 'on' : 'off');
+      if (!on && synth) synth.cancel();
+    },
+    toggle() { this.setEnabled(!this.enabled); return this.enabled; },
+
+    /** Time-aware greeting like the films. */
+    greeting() {
+      const h = new Date().getHours();
+      const part = h < 12 ? 'Good morning' : h < 18 ? 'Good afternoon' : 'Good evening';
+      this.speak(`${part}, sir. JARVIS online. All systems are operational.`, { priority: true });
+    },
+
+    // --- Speech recognition ---------------------------------------
+
+    _setupRecognition() {
+      const r = new SpeechRecognition();
+      r.lang = 'en-US';
+      r.continuous = false;
+      r.interimResults = false;
+      r.maxAlternatives = 1;
+      r.onresult = (e) => {
+        const transcript = (e.results[0][0].transcript || '').trim();
+        _emit('jarvis:heard', { transcript });
+        if (this.commandHandler) {
+          const handled = this.commandHandler(transcript);
+          if (handled) _emit('jarvis:command', { transcript });
+        }
+      };
+      r.onerror = () => { /* mic denied / no-speech — fail quiet */ };
+      r.onend = () => {
+        this.listening = false;
+        _emit('jarvis:listening-end', {});
+      };
+      this.recognition = r;
+    },
+
+    startListening() {
+      if (!this.recognition || this.listening) return false;
+      try {
+        this.recognition.start();
+        this.listening = true;
+        _emit('jarvis:listening-start', {});
+        return true;
+      } catch (_) { return false; }
+    },
+    stopListening() {
+      if (this.recognition && this.listening) {
+        try { this.recognition.stop(); } catch (_) {}
+      }
+    },
+    toggleListening() {
+      return this.listening ? (this.stopListening(), false) : this.startListening();
+    },
+  };
+
+  function _emit(name, detail) {
+    try { window.dispatchEvent(new CustomEvent(name, { detail })); } catch (_) {}
+  }
+
+  window.JarvisVoice = JarvisVoice;
+})();


### PR DESCRIPTION
Turns Mission Control into an **Iron Man-style JARVIS interface** — two-way voice + a cinematic HUD. Everything is **additive and toggleable**; no existing functionality changed, and it builds on the dashboard's existing theme system (the `jarvis` palette already existed — this brings it to life).

## 🎙️ Two-way voice — `dashboard/js/jarvis-voice.js`
- **Speaks** via the Web Speech API, auto-selecting a British English voice to match the films (graceful fallback to any English voice).
- **Listens** for spoken commands via `SpeechRecognition` (Chrome/Edge). Where unsupported, the mic is hidden and **output still works everywhere**.
- **Commands:** status report · open chat/reports/schedules/events/GitHub · "create task &lt;title&gt;" · switch theme (jarvis/matrix) · mute/unmute · greeting.
- **Event announcements** wired to the *real* WebSocket bus: new task, task **DONE**/**BLOCKED** (de-duped per task), review submitted/approved, quota exceeded, uplink lost/restored.

## 🌀 Cinematic HUD — `dashboard/js/jarvis-hud.js` + `dashboard/css/jarvis-hud.css`
- Power-up **boot sequence** ("INITIALIZING JARVIS…") with a skip button.
- Animated **arc-reactor** (header logo + boot centerpiece).
- Ambient **HUD chrome**: corner reticles, sweeping scan line, grid vignette.
- Reactive **voice dock**: arc-reactor orb + waveform + mic/mute/power buttons + status, plus live **subtitles** of what JARVIS says/hears.

## 🎨 Theme
- **Arc-reactor blue is now the default** (`data-color-theme="jarvis"`), set via a no-flash early `<head>` script. Matrix and every other theme stay selectable.
- **JARVIS mode is toggleable** (dock power button or `window.toggleJarvisMode()`) and persisted in `localStorage`. An "ENABLE JARVIS" launcher appears when it's off.
- Respects `prefers-reduced-motion`; all HUD overlays are `pointer-events:none` so they never block the UI.

## Verification
- All three new assets serve `200` from the running server; the dashboard references them and the `jarvis-mode` / theme hooks.
- `node --check` passes on all JS; existing behavior untouched.

## Notes
- Browser **autoplay policies** mean the boot greeting may stay silent until the first user interaction (clicking the mic/mute dock satisfies this) — expected, and the visuals run regardless.
- CHANGELOG entry added under **[Unreleased]** — no version bump in this PR; the release version is your call (this is naturally a 2.2.0 feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjzsdXAue3qYLerJYMPE6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjzsdXAue3qYLerJYMPE6Z)_