### PR TITLE
fix: post-merge review fixes — schema-valid voice tasks + untrack live bot config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ coverage/
 # Operational data — never commit
 .mission-control/reports/
 .mission-control/archived-tasks/
+# Live Telegram bot mapping — deployment-specific (template lives in examples/config/agents.json)
+.mission-control/config/agents.json
 .mission-control/logs/activity.log
 .mission-control/logs/*.log
 .mission-control/tasks/*.json

--- a/.mission-control/config/agents.json
+++ b/.mission-control/config/agents.json
@@ -1,9 +1,0 @@
-{
-  "description": "Agent bot mapping configuration",
-  "botMapping": {
-    "@YourFirstBot": "agent-one",
-    "@YourSecondBot": "agent-two",
-    "@YourThirdBot": "agent-three"
-  },
-  "notes": "Replace with your actual Telegram bot usernames and agent IDs. Keep real production values out of version control."
-}

--- a/dashboard/js/jarvis-hud.js
+++ b/dashboard/js/jarvis-hud.js
@@ -273,7 +273,13 @@
       const nice = title.charAt(0).toUpperCase() + title.slice(1);
       const api = window.MissionControlAPI;
       if (api && typeof api.createTask === 'function') {
-        api.createTask({ title: nice, status: 'INBOX', priority: 'medium', created_by: 'jarvis-voice' })
+        api.createTask({
+            title: nice,
+            description: `Created by voice command via JARVIS: "${nice}".`,
+            status: 'INBOX',
+            priority: 'medium',
+            created_by: 'agent-jarvis-voice'   // schema: ^(agent-|human-|system)...
+          })
           .then(() => { say(`Task created: ${nice}.`); if (typeof window.renderDashboard === 'function') window.renderDashboard(); })
           .catch(() => say('I was unable to create that task, sir.'));
       } else {


### PR DESCRIPTION
Addresses both review comments from #151 (already merged). Small, surgical. **51/51 tests pass.**

### 1. 🎙️ Valid voice-created tasks — `dashboard/js/jarvis-hud.js`
The `create task …` voice command posted a payload missing `description` and with `created_by: 'jarvis-voice'`, which **fails `task.schema.json`** (it requires a `description` and a `created_by` matching `^(agent-|human-|system)…`). Now sends a real `description` and `created_by: 'agent-jarvis-voice'`, so voice tasks validate.

### 2. 📨 Untrack the live Telegram bot mapping — `.mission-control/config/agents.json`
Sanitizing this **tracked** file to placeholders broke file-based Telegram routing: `telegram-bridge.js` reads its `botMapping` when `AGENT_MAP` is unset, so real `@OracleM_Bot`/`@TankMatrixZ_Bot` mentions stopped matching (`/api/telegram/task` → "No agent mentioned").

It's deployment-specific live data, so it's now **gitignored + untracked** — consistent with how the rest of `.mission-control/` runtime data is handled. The placeholder template stays at `examples/config/agents.json`.

> ⚠️ **Deployment note:** after this lands, recreate `.mission-control/config/agents.json` on your server with your real `botMapping` (pulls will no longer overwrite it), **or** set the `AGENT_MAP` env var. Your real mapping was:
> ```json
> { "botMapping": { "@OracleM_Bot": "oracle", "@TankMatrixZ_Bot": "tank", "@MorpheusMatrixZ_Bot": "morpheus", "@ShuriMatrixZ_Bot": "shuri", "@KeymakerMatrixZ_Bot": "keymaker" } }
> ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjzsdXAue3qYLerJYMPE6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjzsdXAue3qYLerJYMPE6Z)_