### PR TITLE
fix: file watcher never fires — dotfile ignore regex matches the watch root itself

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,7 @@ GITHUB_REPO=owner/repo
 # SERVER
 # ============================================
 PORT=3000
+
+# File watcher: set to "true" to poll instead of using native fs events
+# (helps on network mounts and some Windows/container setups)
+MC_WATCH_POLLING=

--- a/server/index.js
+++ b/server/index.js
@@ -477,9 +477,20 @@ async function triggerWebhooks(event, data) {
 // =====================================
 
 const watcher = chokidar.watch(MISSION_CONTROL_DIR, {
-    ignored: /(^|[\/\\])\../, // ignore dotfiles
+    // Ignore dotfiles inside the tree (.initialized, .demo-loaded) — but never
+    // the watch root itself: MISSION_CONTROL_DIR is a dot-folder
+    // (".mission-control"), so a plain dotfile regex like /(^|[\/\\])\../
+    // matches the root path and chokidar ignores the entire tree.
+    ignored: (watchedPath) => {
+        if (path.resolve(watchedPath) === path.resolve(MISSION_CONTROL_DIR)) return false;
+        return path.basename(watchedPath).startsWith('.');
+    },
     persistent: true,
-    ignoreInitial: true
+    ignoreInitial: true,
+    // Native fs events are unreliable on some setups (network mounts, some
+    // Windows/container environments). Set MC_WATCH_POLLING=true to poll instead.
+    usePolling: process.env.MC_WATCH_POLLING === 'true',
+    interval: 1000
 });
 
 watcher


### PR DESCRIPTION
## Bug

The file watcher in `server/index.js` (~line 479) is configured with:

```js
ignored: /(^|[\/\])\../, // ignore dotfiles
```

`MISSION_CONTROL_DIR` is itself a dot-folder (`.mission-control`), so this regex matches the **watch root path**, and chokidar ignores the entire tree. No `add` / `change` / `unlink` event ever fires.

Practical effect: anything written into the data dir from outside the API — an agent dropping a task JSON into `.mission-control/tasks/`, a hand edit, another tool — is invisible to the server and to connected dashboards until the 5-minute read cache expires. (`CACHE_TTL_MS`'s comment calls it a "safety net for missed fs events"; with this bug it is the *only* update path.) WebSocket file-change broadcasts for external edits never happen.

The regex has a second, latent problem: it tests the full absolute path, so any dotted ancestor directory (e.g. a deployment under `/home/user/.local/share/…`) would also silently disable the watcher.

## Repro

1. `npm start`.
2. Write a valid task JSON directly into the data dir, simulating an external agent:
   ```bash
   cat > .mission-control/tasks/repro-task.json <<'JSON'
   {"id":"task-repro-1","title":"External write repro","status":"inbox","createdAt":"2026-07-05T00:00:00.000Z"}
   JSON
   ```
3. `GET /api/tasks` — the task is missing, and no watcher log line (`File added: …`) is emitted. It only shows up after the cache TTL expires (up to 5 minutes later).

Minimal demonstration of the root cause:

```js
/(^|[\/\])\../.test('/path/to/.mission-control')  // → true (watch root ignored)
```

## Fix

Replace the regex with an ignore function that never ignores the watch root, while still ignoring dotfiles *inside* the tree (`.initialized`, `.demo-loaded` stay excluded):

```js
ignored: (watchedPath) => {
    if (path.resolve(watchedPath) === path.resolve(MISSION_CONTROL_DIR)) return false;
    return path.basename(watchedPath).startsWith('.');
},
```

Once the root is no longer ignored, native fs events work normally, so behavior on Linux/macOS is unchanged apart from actually firing. For environments where native events are unreliable (network mounts, some Windows/container setups) this also adds **opt-in** polling via `MC_WATCH_POLLING=true`, following the existing `MC_*` env convention and documented in `.env.example`. Polling stays off by default.

## Verification

Standalone chokidar 3.5.3 harness watching a fresh `.mission-control/tasks/` tree, writing a task JSON one second after watch start (Windows 11, native events, polling off):

| ignored config | events observed |
|---|---|
| upstream regex | `[]` |
| patched function | `["add tasks/repro-task.json"]` (and a `.initialized` written at the root stayed ignored) |

`node --check server/index.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
